### PR TITLE
Fix cannot remap_keys when using "window focus follows the mouse"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /xremap
 /mruby
+tags
+TAGS

--- a/mrblib/xremap/active_window.rb
+++ b/mrblib/xremap/active_window.rb
@@ -19,6 +19,7 @@ module Xremap
     private
 
     def fetch_active_window
+      sleep 0.1
       XlibWrapper.fetch_active_window(@display)
     end
   end


### PR DESCRIPTION
Thanks for the life-changing tool!

I am using [awesome wm](https://awesomewm.org).
Awesome wm use "window focus follows the mouse" feature. 
This feature enables to change the window focus without clicking windows.

As I mentioned in #16, I found xremap cannot remap keys if the window focus was changed by the mouse focus.

This patch fixes the problem adding delay before `fetch_active_window`. 

Thanks