### PR TITLE
Make fetch_window_class look up the parent window if get WM_CLASS failed

### DIFF
--- a/src/xlib_wrapper.c
+++ b/src/xlib_wrapper.c
@@ -17,7 +17,18 @@ mrb_xw_fetch_window_class(mrb_state *mrb, mrb_value self)
   Atom net_wm_name = XInternAtom(display, "WM_CLASS", True);
 
   XTextProperty prop;
-  XGetTextProperty(display, window, &prop, net_wm_name);
+
+ get_wm_name:
+
+  if (!XGetTextProperty(display, window, &prop, net_wm_name)) {
+    unsigned int nchildren;
+    Window root, parent, *children;
+    if (XQueryTree(display, window, &root, &parent, &children, &nchildren)) {
+      if (children) { XFree(children); }
+      window = parent;
+      goto get_wm_name;
+    }
+  }
 
   mrb_value ret;
   if (prop.nitems > 0 && prop.value) {

--- a/src/xlib_wrapper.c
+++ b/src/xlib_wrapper.c
@@ -18,16 +18,15 @@ mrb_xw_fetch_window_class(mrb_state *mrb, mrb_value self)
 
   XTextProperty prop;
 
- get_wm_name:
+  while (1) {
+    if (XGetTextProperty(display, window, &prop, net_wm_name)) { break; }
 
-  if (!XGetTextProperty(display, window, &prop, net_wm_name)) {
     unsigned int nchildren;
     Window root, parent, *children;
-    if (XQueryTree(display, window, &root, &parent, &children, &nchildren)) {
-      if (children) { XFree(children); }
-      window = parent;
-      goto get_wm_name;
-    }
+
+    if (!XQueryTree(display, window, &root, &parent, &children, &nchildren)) { break; }
+    if (children) { XFree(children); }
+    window = parent;
   }
 
   mrb_value ret;


### PR DESCRIPTION
Some applications have the window without name, such as Firefox.

c.f.
> XGetInputFocus() returns an unnamed child window
> that every instance of Firefox has.
https://burrows.svbtle.com/universal-copy-paste-in-linux