### PR TITLE
Fix event handling lag

### DIFF
--- a/mrblib/xremap/active_window.rb
+++ b/mrblib/xremap/active_window.rb
@@ -19,7 +19,7 @@ module Xremap
     private
 
     def fetch_active_window
-      sleep 0.1
+      sleep 0.001
       XlibWrapper.fetch_active_window(@display)
     end
   end


### PR DESCRIPTION
On KDE 4 switching between virtual desktops results in a flood of `PropertyNotify` event: https://github.com/k0kubun/xremap/blob/cef2ca36ee0392f1ac2cd775c200c721f798dd2f/tools/xremap/main.c#L56

Coupled with the specified delay of 100ms in this file, and the fact that `KeyPress` event is handled last, it results in a 1+ second lag.

I don't know whether there's a justification for the existing, specific 100ms delay, but 1ms seem to be ok for me.