### PR TITLE
guard segfault if window not found

### DIFF
--- a/mrblib/xremap/grab_manager.rb
+++ b/mrblib/xremap/grab_manager.rb
@@ -9,6 +9,10 @@ module Xremap
 
     def grab_keys_for(window)
       XlibWrapper.ungrab_keys(@display)
+
+      # guard segmentation fault
+      return if window == 0
+
       @config.remaps_for(@display, window).each do |remap|
         from = remap.from_key
         XlibWrapper.grab_key(@display, from.keysym, from.modifier)

--- a/mrblib/xremap/key_remap_compiler.rb
+++ b/mrblib/xremap/key_remap_compiler.rb
@@ -9,6 +9,10 @@ module Xremap
     # @return [Hash] : keycode(Fixnum) -> state(Fixnum) -> handler(Proc)
     def compile_for(window)
       result = Hash.new { |h, k| h[k] = {} }
+
+      # guard segmentation fault
+      return result if window == 0
+
       set_handlers_for(result, window)
       result
     end


### PR DESCRIPTION
The segmentation fault error has occured.

![screenshot from 2018-01-04 01-42-17](https://user-images.githubusercontent.com/456515/34529845-967d1872-f0f0-11e7-9d15-b61e0a11cc92.png)

I use GNOME and wayland as default x server.
It seems that window can not be taken when focusing on GNOME application such as Nautilus.