### PR TITLE
Pass unmatched modifiers

### DIFF
--- a/mrblib/xremap/event_handler.rb
+++ b/mrblib/xremap/event_handler.rb
@@ -3,18 +3,19 @@ module Xremap
     # @param [Xremap::Config] config
     # @param [Xremap::Display] display
     def initialize(config, display)
+      @display = display
       @active_window = ActiveWindow.new(display)
       @grab_manager  = GrabManager.new(config, display)
       @key_remap_compiler = KeyRemapCompiler.new(config, display)
       remap_keys
     end
 
-    def handle_key_press(keycode, state)
-      handler = @key_press_handlers[keycode][state]
+    def handle_key_press(keycode, input_state)
+      matched_mask, handler = @key_press_handlers[keycode].find { |handler_mask, _handler| bitmask_subset?(input_state, handler_mask) }
       if handler
-        handler.call
+        handler.call(input_state & ~matched_mask)
       else
-        $stderr.puts "Handler not found!: #{[keycode, state, @key_press_handlers].inspect}"
+        XlibWrapper.press_key(@display, XlibWrapper.keycode_to_keysym(@display, keycode), input_state)
       end
     end
 
@@ -34,6 +35,10 @@ module Xremap
       window = @active_window.current_window
       @key_press_handlers = @key_remap_compiler.compile_for(window)
       @grab_manager.grab_keys_for(window)
+    end
+
+    def bitmask_subset?(parent, child)
+      (parent & child) == child
     end
   end
 end

--- a/mrblib/xremap/grab_manager.rb
+++ b/mrblib/xremap/grab_manager.rb
@@ -15,7 +15,7 @@ module Xremap
 
       @config.remaps_for(@display, window).each do |remap|
         from = remap.from_key
-        XlibWrapper.grab_key(@display, from.keysym, from.modifier)
+        XlibWrapper.grab_key(@display, from.keysym, X11::AnyModifier)
       end
 
       # TODO: remove this log

--- a/src/xlib_wrapper.c
+++ b/src/xlib_wrapper.c
@@ -156,6 +156,17 @@ mrb_xw_keysym_to_keycode(mrb_state *mrb, mrb_value self)
 }
 
 mrb_value
+mrb_xw_keycode_to_keysym(mrb_state *mrb, mrb_value self)
+{
+  mrb_value display_obj;
+  mrb_int keycode;
+  mrb_get_args(mrb, "oi", &display_obj, &keycode);
+
+  Display *display = extract_x_display(mrb, display_obj);
+  return mrb_fixnum_value(XKeycodeToKeysym(display, keycode, 0));
+}
+
+mrb_value
 mrb_xw_fetch_active_window(mrb_state *mrb, mrb_value self)
 {
   mrb_value display_obj;
@@ -199,6 +210,7 @@ mrb_xremap_xlib_wrapper_init(mrb_state *mrb, struct RClass *mXremap)
   mrb_define_class_method(mrb, cXlibWrapper, "press_key",           mrb_xw_press_key,           MRB_ARGS_REQ(3));
   mrb_define_class_method(mrb, cXlibWrapper, "release_key",         mrb_xw_release_key,         MRB_ARGS_REQ(3));
   mrb_define_class_method(mrb, cXlibWrapper, "keysym_to_keycode",   mrb_xw_keysym_to_keycode,   MRB_ARGS_REQ(2));
+  mrb_define_class_method(mrb, cXlibWrapper, "keycode_to_keysym",   mrb_xw_keycode_to_keysym,   MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, cXlibWrapper, "fetch_active_window", mrb_xw_fetch_active_window, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, cXlibWrapper, "fetch_window_class",  mrb_xw_fetch_window_class,  MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, cXlibWrapper, "grab_key",            mrb_xw_grab_key,            MRB_ARGS_REQ(3));


### PR DESCRIPTION
This patch implements "pass-through" of unmached modifiers.

## Why

Karabinar ignores unmached modifiers, and apply ignored modifiers to modified key input.
For example, if we map `Ctrl+j` to `↓`(keydown), inputs like `Ctrl+Shift+j` is modified to `Shift+↓` so we can select multiple lines in text editors.

On the other hand, xremap does not ignore unmached modifiers (in previous example, `Shift`), so `Ctrl+Shift+j` maches to nothing, and we cannot select lines.

## What

With this patch, xremap maches modifiers to their "superset" modifiers, and apply remaining modifiers to the resulting key inputs. For example, if `Ctrl+Shift+j` is input, it matches to `Ctrl+j`, and apply `Shift` to resulting key input `↓`.