### PR TITLE
introduce log/env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-io"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +27,17 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
  "winapi",
 ]
 
@@ -108,6 +128,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -254,6 +287,21 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
@@ -445,6 +493,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +635,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,9 +753,11 @@ dependencies = [
 name = "xremap"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "evdev",
  "getopts",
  "lazy_static",
+ "log",
  "nix 0.23.1",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+env_logger = "0.9.0"
 evdev = "0.11.3"
 getopts = "0.2"
-swayipc = { git = "https://github.com/k0kubun/swayipc-rs" }
 lazy_static = "1.4.0"
+log = "0.4.14"
 nix = "0.23.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
+swayipc = { git = "https://github.com/k0kubun/swayipc-rs" }
 x11_rs = { package = "x11", version = "2.19.1", features = ["xlib"] }
 zbus = "1.9.2"
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -6,6 +6,7 @@ use crate::Config;
 use evdev::uinput::VirtualDevice;
 use evdev::{EventType, InputEvent, Key};
 use lazy_static::lazy_static;
+use log::debug;
 use std::collections::HashMap;
 use std::error::Error;
 
@@ -38,7 +39,7 @@ impl EventHandler {
     pub fn on_event(&mut self, event: InputEvent, config: &Config) -> Result<(), Box<dyn Error>> {
         self.application_cache = None; // expire cache
         let mut key = Key::new(event.code());
-        // println!("=> {}: {:?}", event.value(), &key);
+        debug!("=> {}: {:?}", event.value(), &key);
 
         // Apply modmap
         for modmap in &config.modmap {
@@ -62,13 +63,14 @@ impl EventHandler {
             }
             return Ok(());
         }
-
         self.send_key(&key, event.value())?;
         Ok(())
     }
 
     pub fn send_event(&mut self, event: InputEvent) -> std::io::Result<()> {
-        // if event.event_type() == EventType::KEY { println!("{}: {:?}", event.value(), Key::new(event.code())) }
+        if event.event_type() == EventType::KEY {
+            debug!("{}: {:?}", event.value(), Key::new(event.code()))
+        }
         self.device.emit(&[event])
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn abort(message: &str) -> ! {
 }
 
 fn main() {
+    env_logger::init();
     let argv: Vec<String> = env::args().collect();
     let program = argv[0].clone();
 


### PR DESCRIPTION
This PR introduces log/env_logger. With this patch, you can debug the input against release binary

```
$ sudo RUST_LOG=debug xremap xremap.yaml
...
...
[2021-12-22T15:39:38Z DEBUG xremap::event_handler] 0: KEY_ENTER
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 1: KEY_H
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 1: KEY_H
d[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 0: KEY_H
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 0: KEY_H
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 1: KEY_D
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 1: KEY_D
e[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 0: KEY_D
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 0: KEY_D
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 1: KEY_N
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 1: KEY_N
b[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 0: KEY_N
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 0: KEY_N
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 1: KEY_F
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 1: KEY_F
u[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 0: KEY_F
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 0: KEY_F
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 1: KEY_U
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 1: KEY_U
g[2021-12-22T15:39:41Z DEBUG xremap::event_handler] => 0: KEY_U
[2021-12-22T15:39:41Z DEBUG xremap::event_handler] 0: KEY_U
[2021-12-22T15:39:57Z DEBUG xremap::event_handler] => 1: KEY_LEFTALT
[2021-12-22T15:39:57Z DEBUG xremap::event_handler] 1: KEY_L
```