### PR TITLE
Add --watch option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,14 @@ fn main() {
         Err(e) => abort(&format!("Failed to load config '{}': {}", filename, e)),
     };
 
-    if let Err(e) = event_loop(&config, &args.opt_strs("device"), &args.opt_strs("ignore")) {
-        abort(&format!("Error: {}", e));
+    loop {
+        if let Err(e) = event_loop(&config, &args.opt_strs("device"), &args.opt_strs("ignore")) {
+            if e.to_string().starts_with("No such device") {
+                println!("Found a removed device. Reselecting.");
+                continue;
+            }
+            abort(&format!("Error: {}", e));
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 use crate::config::Config;
-use crate::device::{input_devices, output_device};
+use crate::device::{device_watcher, input_devices, output_device};
 use crate::event_handler::EventHandler;
+use evdev::uinput::VirtualDevice;
 use evdev::{Device, EventType};
 use getopts::Options;
+use nix::sys::inotify::Inotify;
 use nix::sys::select::select;
 use nix::sys::select::FdSet;
 use std::env;
@@ -23,8 +25,9 @@ fn main() {
     let program = argv[0].clone();
 
     let mut opts = Options::new();
-    opts.optmulti("", "device", "Include device name or path", "NAME");
-    opts.optmulti("", "ignore", "Exclude device name or path", "NAME");
+    opts.optmulti("", "device", "Include a device name or path", "NAME");
+    opts.optmulti("", "ignore", "Exclude a device name or path", "NAME");
+    opts.optflag("", "watch", "Add new devices automatically");
     opts.optflag("h", "help", "print this help menu");
 
     let args = match opts.parse(&argv[1..]) {
@@ -45,10 +48,20 @@ fn main() {
         Err(e) => abort(&format!("Failed to load config '{}': {}", filename, e)),
     };
 
+    let watch = args.opt_present("watch");
     loop {
-        if let Err(e) = event_loop(&config, &args.opt_strs("device"), &args.opt_strs("ignore")) {
+        let output_device = match output_device() {
+            Ok(output_device) => output_device,
+            Err(e) => abort(&format!("Failed to prepare an output device: {}", e)),
+        };
+        let input_devices = match input_devices(&args.opt_strs("device"), &args.opt_strs("ignore"), watch) {
+            Ok(input_devices) => input_devices,
+            Err(e) => abort(&format!("Failed to prepare input devices: {}", e)),
+        };
+
+        if let Err(e) = event_loop(output_device, input_devices, &config, watch) {
             if e.to_string().starts_with("No such device") {
-                println!("Found a removed device. Reselecting.");
+                println!("Found a removed device. Reselecting devices.");
                 continue;
             }
             abort(&format!("Error: {}", e));
@@ -56,14 +69,16 @@ fn main() {
     }
 }
 
-fn event_loop(config: &Config, device_opts: &Vec<String>, ignore_opts: &Vec<String>) -> Result<(), Box<dyn Error>> {
-    let output_device = output_device().map_err(|e| format!("Failed to prepare an output device: {}", e))?;
-    let mut input_devices =
-        input_devices(device_opts, ignore_opts).map_err(|e| format!("Failed to prepare input devices: {}", e))?;
-
+fn event_loop(
+    output_device: VirtualDevice,
+    mut input_devices: Vec<Device>,
+    config: &Config,
+    watch: bool,
+) -> Result<(), Box<dyn Error>> {
+    let watcher = device_watcher(watch)?;
     let mut handler = EventHandler::new(output_device);
     loop {
-        let readable_fds = select_readable(&input_devices)?;
+        let readable_fds = select_readable(&input_devices, &watcher)?;
         for input_device in &mut input_devices {
             if readable_fds.contains(input_device.as_raw_fd()) {
                 for event in input_device.fetch_events()? {
@@ -75,13 +90,22 @@ fn event_loop(config: &Config, device_opts: &Vec<String>, ignore_opts: &Vec<Stri
                 }
             }
         }
+        if let Some(inotify) = watcher {
+            if readable_fds.contains(inotify.as_raw_fd()) {
+                println!("Detected a new device. Reselecting devices.");
+                return Ok(());
+            }
+        }
     }
 }
 
-fn select_readable(devices: &Vec<Device>) -> Result<FdSet, Box<dyn Error>> {
+fn select_readable(devices: &Vec<Device>, watcher: &Option<Inotify>) -> Result<FdSet, Box<dyn Error>> {
     let mut read_fds = FdSet::new();
     for device in devices {
         read_fds.insert(device.as_raw_fd());
+    }
+    if let Some(inotify) = watcher {
+        read_fds.insert(inotify.as_raw_fd());
     }
     select(None, &mut read_fds, None, None, None)?;
     return Ok(read_fds);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,14 @@
 use crate::config::Config;
 use crate::device::{input_devices, output_device};
-use crate::event_handler::event_loop;
+use crate::event_handler::EventHandler;
+use evdev::uinput::VirtualDevice;
+use evdev::{Device, EventType};
 use getopts::Options;
+use nix::sys::select::select;
+use nix::sys::select::FdSet;
 use std::env;
+use std::error::Error;
+use std::os::unix::io::AsRawFd;
 use std::process::exit;
 
 extern crate getopts;
@@ -11,16 +17,6 @@ mod client;
 mod config;
 mod device;
 mod event_handler;
-
-fn usage(program: &str, opts: Options) -> String {
-    let brief = format!("Usage: {} CONFIG [options]", program);
-    opts.usage(&brief)
-}
-
-fn abort(message: &str) -> ! {
-    println!("{}", message);
-    exit(1);
-}
 
 fn main() {
     env_logger::init();
@@ -62,4 +58,45 @@ fn main() {
     if let Err(e) = event_loop(input_devices, output_device, &config) {
         abort(&format!("Error: {}", e));
     }
+}
+
+fn event_loop(
+    mut input_devices: Vec<Device>,
+    output_device: VirtualDevice,
+    config: &Config,
+) -> Result<(), Box<dyn Error>> {
+    let mut handler = EventHandler::new(output_device);
+    loop {
+        let readable_fds = select_readable(&input_devices)?;
+        for input_device in &mut input_devices {
+            if readable_fds.contains(input_device.as_raw_fd()) {
+                for event in input_device.fetch_events()? {
+                    if event.event_type() == EventType::KEY {
+                        handler.on_event(event, config)?;
+                    } else {
+                        handler.send_event(event)?;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn select_readable(devices: &Vec<Device>) -> Result<FdSet, Box<dyn Error>> {
+    let mut read_fds = FdSet::new();
+    for device in devices {
+        read_fds.insert(device.as_raw_fd());
+    }
+    select(None, &mut read_fds, None, None, None)?;
+    return Ok(read_fds);
+}
+
+fn usage(program: &str, opts: Options) -> String {
+    let brief = format!("Usage: {} CONFIG [options]", program);
+    opts.usage(&brief)
+}
+
+fn abort(message: &str) -> ! {
+    println!("{}", message);
+    exit(1);
 }


### PR DESCRIPTION
## Summary
Add `--watch` option to automatically add new devices to xremap's management

## Example
```
$ xremap config.yml --watch
...
Detected device changes. Reselecting devices.
...
------------------------------------------------------------------------------
warning: No device was selected, but --watch is waiting for new devices.
------------------------------------------------------------------------------
...
Detected device changes. Reselecting devices.
...
Selected keyboards automatically since --device options weren't specified:
------------------------------------------------------------------------------
/dev/input/event19: PFU Limited  HHKB Professional JP
------------------------------------------------------------------------------
...
```