### PR TITLE
Switch to #[derive(Deserialize)]

### DIFF
--- a/src/config/key_action.rs
+++ b/src/config/key_action.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 // Values in `modmap.remap`
 #[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
 pub enum KeyAction {
     Key(Key),
     MultiPurposeKey(MultiPurposeKey),

--- a/src/config/key_action.rs
+++ b/src/config/key_action.rs
@@ -1,10 +1,8 @@
 use crate::config::key::Key;
-use serde::de::{IntoDeserializer, MapAccess, Visitor};
-use serde::{Deserialize, Deserializer};
-use std::fmt::Formatter;
+use serde::Deserialize;
 
 // Values in `modmap.remap`
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub enum KeyAction {
     Key(Key),
     MultiPurposeKey(MultiPurposeKey),
@@ -21,40 +19,5 @@ pub struct MultiPurposeKey {
 impl MultiPurposeKey {
     fn default_alone_timeout_millis() -> u64 {
         1000
-    }
-}
-
-impl<'de> Deserialize<'de> for KeyAction {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct ActionVisitor;
-
-        impl<'de> Visitor<'de> for ActionVisitor {
-            type Value = KeyAction;
-
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-                formatter.write_str("string or map")
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                let key = Deserialize::deserialize(value.into_deserializer())?;
-                Ok(KeyAction::Key(key))
-            }
-
-            fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
-            where
-                M: MapAccess<'de>,
-            {
-                let multi_purpose_key = Deserialize::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
-                Ok(KeyAction::MultiPurposeKey(multi_purpose_key))
-            }
-        }
-
-        deserializer.deserialize_any(ActionVisitor)
     }
 }


### PR DESCRIPTION
~This change fails to deserialize:~

```yml
modmap:
  - remap:
      Space:
        held: Shift_L
        alone: Space
        alone_timeout_millis: 500
```

~with an error like:~

> ~Failed to load config 'example/test.yml': modmap[0].remap: unknown variant `held`, expected `Key` or `MultiPurposeKey` at line 3 column 12~

resolved by the second commit.