### PR TITLE
Add hotkey command support

### DIFF
--- a/example/hotkey_test.yml
+++ b/example/hotkey_test.yml
@@ -1,0 +1,10 @@
+hotkeys:
+  - name: hotkey_test
+    keys:
+      - KEY_GRAVE
+    application:
+      not: [Google-chrome, konsole]
+    command:
+      - "/bin/sh"
+      - "-c"
+      - "date > /tmp/hotkey_test"

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,32 @@
+use std::process::{Command, Stdio};
+use std::thread;
+use log::{debug, error};
+
+pub fn run_command(command: Vec<String>) {
+    // To avoid defunct processes, spawn a thread to wait on the process.
+    thread::spawn(move || {
+        debug!("Running command: {:?}", command);
+        match Command::new(&command[0])
+            .args(&command[1..])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Err(e) => {
+                error!("Error running command: {:?}", e);
+            }
+            Ok(mut child) => {
+                debug!("Process spawned: {:?}, pid {}", command, child.id());
+                match child.wait() {
+                    Ok(status) => {
+                        debug!("Process exited: pid: {}, status: {:?}", child.id(), status);
+                    }
+                    Err(e) => {
+                        error!("Error from process: {:?}", e);
+                    }
+                }
+            }
+        }
+    });
+}

--- a/src/config/hotkey.rs
+++ b/src/config/hotkey.rs
@@ -1,0 +1,13 @@
+use crate::config::application::Application;
+use crate::config::key_press::KeyPress;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Hotkey {
+    #[serde(default = "String::new")]
+    pub name: String,
+    pub keys: Vec<KeyPress>,
+    pub command: Vec<String>,
+    pub application: Option<Application>,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod application;
 pub mod key;
 pub mod key_action;
 pub mod key_press;
+mod hotkey;
 mod keymap;
 mod modmap;
 
@@ -13,6 +14,7 @@ extern crate serde_yaml;
 
 use keymap::Keymap;
 use modmap::Modmap;
+use hotkey::Hotkey;
 use serde::Deserialize;
 use std::error::Error;
 use std::fs;
@@ -24,6 +26,8 @@ pub struct Config {
     pub modmap: Vec<Modmap>,
     #[serde(default = "Vec::new")]
     pub keymap: Vec<Keymap>,
+    #[serde(default = "Vec::new")]
+    pub hotkeys: Vec<Hotkey>,
 }
 
 pub fn load_config(filename: &str) -> Result<Config, Box<dyn Error>> {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,4 +1,5 @@
 use crate::client::{build_client, WMClient};
+use crate::command::run_command;
 use crate::config::action::Action;
 use crate::config::application::Application;
 use crate::config::key_action::KeyAction;
@@ -57,9 +58,13 @@ impl EventHandler {
 
         // Apply keymap
         for (key, value) in key_values.into_iter() {
-            if MODIFIER_KEYS.contains(&key.code()) {
+            let key_press = self.key_to_key_press(&key);
+            // Run hotkey commands
+            if self.handle_hotkey(&key_press, value, &config) {
+                return Ok(());
+            } else if MODIFIER_KEYS.contains(&key.code()) {
                 self.update_modifier(key.code(), value);
-            } else if let Some(actions) = self.find_keymap(config, &key, value) {
+            } else if let Some(actions) = self.find_keymap(config, &key_press, value) {
                 for action in &actions {
                     self.dispatch_action(action)?;
                 }
@@ -68,6 +73,25 @@ impl EventHandler {
             self.send_key(&key, value)?;
         }
         Ok(())
+    }
+
+    fn handle_hotkey(&mut self, key_press: &KeyPress, value: i32, config: &Config) -> bool {
+        let mut hotkey_used = false;
+        'outer_hotkey: for hotkey in &config.hotkeys {
+            for hotkey_key_press in &hotkey.keys {
+                if hotkey_key_press == key_press && is_pressed(value) {
+                    if let Some(app) = &hotkey.application {
+                        if !self.match_application(app) {
+                            continue 'outer_hotkey;
+                        }
+                    }
+                    run_command(hotkey.command.clone());
+                    hotkey_used = true;
+                    break 'outer_hotkey;
+                }
+            }
+        }
+        return hotkey_used;
     }
 
     pub fn send_event(&mut self, event: InputEvent) -> std::io::Result<()> {
@@ -150,18 +174,21 @@ impl EventHandler {
         None
     }
 
-    fn find_keymap(&mut self, config: &Config, key: &Key, value: i32) -> Option<Vec<Action>> {
-        if !is_pressed(value) {
-            return None;
-        }
-
-        let key_press = KeyPress {
+    fn key_to_key_press(&mut self, key: &Key) -> KeyPress {
+        KeyPress {
             key: key.clone(),
             shift: self.shift.left || self.shift.right,
             control: self.control.left || self.control.right,
             alt: self.alt.left || self.alt.right,
             windows: self.windows.left || self.windows.right,
-        };
+        }
+    }
+
+    fn find_keymap(&mut self, config: &Config, key_press: &KeyPress, value: i32) -> Option<Vec<Action>> {
+        if !is_pressed(value) {
+            return None;
+        }
+
         if let Some(override_remap) = &self.override_remap {
             let override_remap = override_remap.clone();
             self.override_remap = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use std::process::exit;
 extern crate getopts;
 
 mod client;
+mod command;
 mod config;
 mod device;
 mod event_handler;


### PR DESCRIPTION
Hello,

I was wondering if you might be interested in an extension of xremap to support something like [xbindkeys](https://www.nongnu.org/xbindkeys/), where a key can be mapped to an external command.  I had a similar need you described, where app-specific bindings were useful, and I thought it could be a little cleaner than having that in the config rather than a window check in each command. I found your project here and was able to hack this in quickly!

What's here so far is pretty simple. A new config kind is added, `hotkeys`, which you can specify the same `application` and `name`, and `keys` for each hotkey to trigger from. `command` for specifying the executable and arguments as an array.  As implemented it happens _after_ remap, but before the keymap phase.

A few thoughts where this could go:
* Add a `forward_key_press` option. As-is it swallows the key press, but it could propagate that on.
* Wire this up such that it happens after keymap. Or go backward, and do it before remap. I thought it made more sense to do after remap.
* Build a table of hotkey commands at config parse, so we don't have to iterate every command (performance).
* Docs, examples.

Thanks for taking a look, and I fully understand if this is not something you're interested in supporting.

Thanks for the great project!