### PR TITLE
Implement mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 * Remap a key to two different keys depending on whether it's pressed alone or held.
 * Application-specific remapping. Even if it's not supported by your application, xremap can.
 * Automatically remap newly connected devices by starting xremap with `--watch`.
+* Support [Emacs-like key remapping](example/emacs.yml), including the mark mode.
 
 ## Prerequisite
 
@@ -146,6 +147,10 @@ keymap:
       # execute a command
       MOD1-KEY_XXX:
         launch: ["bash", "-c", "echo hello > /tmp/test"]
+      # let `with_mark` also press a Shift key (useful for Emacs emulation)
+      MOD1-KEY_XXX: { set_mark: true } # use { set_mark: false } to disable it
+      # also press Shift only when { set_mark: true } is used before
+      MOD1-KEY_XXX: { with_mark: MOD2-KEY_YYY }
     application: # Optional
       not: [Application, ...]
       # or

--- a/example/emacs.yml
+++ b/example/emacs.yml
@@ -1,0 +1,60 @@
+# Credit: https://github.com/mooz/xkeysnail/blob/bf3c93b4fe6efd42893db4e6588e5ef1c4909cfb/example/config.py#L62-L125
+keymap:
+  - name: Emacs
+    remap:
+      # Cursor
+      C-b: { with_mark: left }
+      C-f: { with_mark: right }
+      C-p: { with_mark: up }
+      C-n: { with_mark: down }
+      # Forward/Backward word
+      M-b: { with_mark: C-left }
+      M-f: { with_mark: C-right }
+      # Beginning/End of line
+      C-a: { with_mark: home }
+      C-e: { with_mark: end }
+      # Page up/down
+      M-v: { with_mark: pageup }
+      C-v: { with_mark: pagedown }
+      # Beginning/End of file
+      M-Shift-comma: { with_mark: C-home }
+      M-Shift-dot: { with_mark: C-end }
+      # Newline
+      C-m: enter
+      C-j: enter
+      C-o: [enter, left]
+      # Copy
+      C-w: [C-x, { set_mark: false }]
+      M-w: [C-c, { set_mark: false }]
+      C-y: [C-v, { set_mark: false }]
+      # Delete
+      C-d: [delete, { set_mark: false }]
+      M-d: [C-delete, { set_mark: false }]
+      # Kill line
+      C-k: [Shift-end, C-x, { set_mark: false }]
+      # Undo
+      C-slash: [C-z, { set_mark: false }]
+      C-Shift-ro: C-z
+      # Mark
+      C-space: { set_mark: true }
+      # Search
+      C-s: F3
+      C-r: Shift-F3
+      M-Shift-5: C-h
+      # Cancel
+      C-g: [esc, { set_mark: false }]
+      # C-x YYY
+      C-x:
+        remap:
+          # C-x h (select all)
+          h: [C-home, C-a, { set_mark: true }]
+          # C-x C-f (open)
+          C-f: C-o
+          # C-x C-s (save)
+          C-s: C-s
+          # C-x k (kill tab)
+          k: C-f4
+          # C-x C-c (exit)
+          C-c: C-q
+          # C-x u (undo)
+          u: [C-z, { set_mark: false }]

--- a/src/config/action.rs
+++ b/src/config/action.rs
@@ -14,6 +14,10 @@ pub enum Action {
     Remap(HashMap<KeyPress, Vec<Action>>),
     #[serde(deserialize_with = "deserialize_launch")]
     Launch(Vec<String>),
+    #[serde(deserialize_with = "deserialize_with_mark")]
+    WithMark(KeyPress),
+    #[serde(deserialize_with = "deserialize_set_mark")]
+    SetMark(bool),
 }
 
 fn deserialize_remap<'de, D>(deserializer: D) -> Result<HashMap<KeyPress, Vec<Action>>, D::Error>
@@ -40,6 +44,32 @@ where
         }
     }
     Err(de::Error::custom("not a map with a single \"launch\" key"))
+}
+
+fn deserialize_with_mark<'de, D>(deserializer: D) -> Result<KeyPress, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut action = HashMap::<String, KeyPress>::deserialize(deserializer)?;
+    if let Some(key_press) = action.remove("with_mark") {
+        if action.is_empty() {
+            return Ok(key_press);
+        }
+    }
+    Err(de::Error::custom("not a map with a single \"with_mark\" key"))
+}
+
+fn deserialize_set_mark<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut action = HashMap::<String, bool>::deserialize(deserializer)?;
+    if let Some(set) = action.remove("set_mark") {
+        if action.is_empty() {
+            return Ok(set);
+        }
+    }
+    Err(de::Error::custom("not a map with a single \"set_mark\" key"))
 }
 
 // Used only for deserializing Vec<Action>

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -114,6 +114,18 @@ fn test_keymap_launch() {
     "#})
 }
 
+#[test]
+fn test_keymap_mark() {
+    assert_parse(indoc! {"
+    keymap:
+      - remap:
+          C-space: { set_mark: true }
+          C-g: [esc, { set_mark: false }]
+          C-b: { with_mark: left }
+          M-b: { with_mark: C-left }
+    "})
+}
+
 fn assert_parse(yaml: &str) {
     let result: Result<Config, Error> = serde_yaml::from_str(&yaml);
     if let Err(e) = result {

--- a/src/device.rs
+++ b/src/device.rs
@@ -26,7 +26,7 @@ static MOUSE_BTNS: [&str; 13] = [
     "BTN_RIGHT",
 ];
 
-// Credit: https://github.com/mooz/xkeysnail/blob/master/xkeysnail/output.py#L10-L32
+// Credit: https://github.com/mooz/xkeysnail/blob/bf3c93b4fe6efd42893db4e6588e5ef1c4909cfb/xkeysnail/output.py#L10-L32
 pub fn output_device() -> Result<VirtualDevice, Box<dyn Error>> {
     let mut keys: AttributeSet<Key> = AttributeSet::new();
     for code in Key::KEY_RESERVED.code()..Key::BTN_TRIGGER_HAPPY40.code() {
@@ -183,7 +183,7 @@ fn match_device(path: &str, device: &Device, device_opts: &Vec<String>) -> bool 
 }
 
 fn is_keyboard(device: &Device) -> bool {
-    // Credit: https://github.com/mooz/xkeysnail/blob/master/xkeysnail/input.py#L17-L32
+    // Credit: https://github.com/mooz/xkeysnail/blob/bf3c93b4fe6efd42893db4e6588e5ef1c4909cfb/xkeysnail/input.py#L17-L32
     match device.supported_keys() {
         Some(keys) => {
             keys.contains(Key::KEY_SPACE)


### PR DESCRIPTION
## Example

```yml
keymap:
  - name: Emacs
    remap:
      # Cursor
      C-b: { with_mark: left }
      C-f: { with_mark: right }
      C-p: { with_mark: up }
      C-n: { with_mark: down }
      # Forward/Backward word
      M-b: { with_mark: C-left }
      M-f: { with_mark: C-right }
      # Beginning/End of line
      C-a: { with_mark: home }
      C-e: { with_mark: end }
      # Page up/down
      M-v: { with_mark: pageup }
      C-v: { with_mark: pagedown }
      # Beginning/End of file
      M-Shift-comma: { with_mark: C-home }
      M-Shift-dot: { with_mark: C-end }
      # Newline
      C-m: enter
      C-j: enter
      C-o: [enter, left]
      # Copy
      C-w: [C-x, { set_mark: false }]
      M-w: [C-c, { set_mark: false }]
      C-y: [C-v, { set_mark: false }]
      # Delete
      C-d: [delete, { set_mark: false }]
      M-d: [C-delete, { set_mark: false }]
      # Kill line
      C-k: [Shift-end, C-x, { set_mark: false }]
      # Undo
      C-slash: [C-z, { set_mark: false }]
      C-Shift-ro: C-z
      # Mark
      C-space: { set_mark: true }
      # Search
      C-s: F3
      C-r: Shift-F3
      M-Shift-5: C-h
      # Cancel
      C-g: [esc, { set_mark: false }]
      # C-x YYY
      C-x:
        remap:
          # C-x h (select all)
          h: [C-home, C-a, { set_mark: true }]
          # C-x C-f (open)
          C-f: C-o
          # C-x C-s (save)
          C-s: C-s
          # C-x k (kill tab)
          k: C-f4
          # C-x C-c (exit)
          C-c: C-q
          # C-x u (undo)
          u: [C-z, { set_mark: false }]
```