### PR TITLE
add an option to show the version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
     opts.optmulti("", "ignore", "Exclude a device name or path", "NAME");
     opts.optflag("", "watch", "Add new devices automatically");
     opts.optflag("h", "help", "print this help menu");
+    opts.optflag("", "version", "show version");
 
     let args = match opts.parse(&argv[1..]) {
         Ok(args) => args,
@@ -36,6 +37,10 @@ fn main() {
     };
     if args.opt_present("h") {
         println!("{}", &usage(&program, opts));
+        return;
+    }
+    if args.opt_present("version") {
+        println!("xremap version {}", env!("CARGO_PKG_VERSION"));
         return;
     }
 


### PR DESCRIPTION
This is useful when you want to check the version and install the latest binary if current is old.

```console
$ cargo run -- --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/xremap --help`
Usage: target/debug/xremap CONFIG [options]

Options:
        --device NAME   Include a device name or path
        --ignore NAME   Exclude a device name or path
        --watch         Add new devices automatically
    -h, --help          print this help menu
        --version       show version

$ cargo run -- --version
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/xremap --version`
xremap version 0.1.7
```

For more detail of `CARGO_PKG_VERSION`, see https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates