### PR TITLE
Left/Right-specific modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ For the `MOD1-` part, the following prefixes can be used (also case-insensitive)
 * Windows: `SUPER-`, `WIN-`, `WINDOWS-`
 
 You can use multiple prefixes like `C-M-Shift-a`.
-You may also prefix them with `L` or `R` (case-insensitive) so that
-remapping is triggered only on a left or right modifier, e.g. `LCtrl-a`.
+You may also suffix them with `_L` or `_R` (case-insensitive) so that
+remapping is triggered only on a left or right modifier, e.g. `Ctrl_L-a`.
 
 ### application
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ For the `MOD1-` part, the following prefixes can be used (also case-insensitive)
 * Alt: `M-`, `ALT-`
 * Windows: `SUPER-`, `WIN-`, `WINDOWS-`
 
-You may use multiple prefixes like `C-M-Shift-a`.
+You can use multiple prefixes like `C-M-Shift-a`.
+You may also prefix them with `L` or `R` (case-insensitive) so that
+remapping is triggered only on a left or right modifier, e.g. `LCtrl-a`.
 
 ### application
 

--- a/src/config/action.rs
+++ b/src/config/action.rs
@@ -73,7 +73,7 @@ where
 }
 
 // Used only for deserializing Vec<Action>
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(untagged)]
 pub enum Actions {
     Action(Action),

--- a/src/config/key_press.rs
+++ b/src/config/key_press.rs
@@ -70,21 +70,37 @@ fn parse_key_press(input: &str) -> Result<KeyPress, Box<dyn error::Error>> {
 
 fn parse_modifier(modifier: &str) -> Option<(Modifier, ModifierState)> {
     // Everything is case-insensitive
-    match &modifier.to_uppercase()[..] {
+    let mut modifier = &modifier.to_uppercase()[..];
+    let mut modifier_state = ModifierState::Either;
+    if modifier.starts_with("L") {
+        modifier = remove_first_char(modifier);
+        modifier_state = ModifierState::Left;
+    } else if modifier.starts_with("R") {
+        modifier = remove_first_char(modifier);
+        modifier_state = ModifierState::Right;
+    }
+
+    match modifier {
         // Shift
-        "SHIFT" => Some((Modifier::Shift, ModifierState::Either)),
+        "SHIFT" => Some((Modifier::Shift, modifier_state)),
         // Control
-        "C" => Some((Modifier::Control, ModifierState::Either)),
-        "CTRL" => Some((Modifier::Control, ModifierState::Either)),
-        "CONTROL" => Some((Modifier::Control, ModifierState::Either)),
+        "C" => Some((Modifier::Control, modifier_state)),
+        "CTRL" => Some((Modifier::Control, modifier_state)),
+        "CONTROL" => Some((Modifier::Control, modifier_state)),
         // Alt
-        "M" => Some((Modifier::Alt, ModifierState::Either)),
-        "ALT" => Some((Modifier::Alt, ModifierState::Either)),
+        "M" => Some((Modifier::Alt, modifier_state)),
+        "ALT" => Some((Modifier::Alt, modifier_state)),
         // Windows
-        "SUPER" => Some((Modifier::Windows, ModifierState::Either)),
-        "WIN" => Some((Modifier::Windows, ModifierState::Either)),
-        "WINDOWS" => Some((Modifier::Windows, ModifierState::Either)),
+        "SUPER" => Some((Modifier::Windows, modifier_state)),
+        "WIN" => Some((Modifier::Windows, modifier_state)),
+        "WINDOWS" => Some((Modifier::Windows, modifier_state)),
         // else
         _ => None,
     }
+}
+
+fn remove_first_char(string: &str) -> &str {
+    let mut chars = string.chars();
+    chars.next();
+    chars.as_str()
 }

--- a/src/config/key_press.rs
+++ b/src/config/key_press.rs
@@ -72,11 +72,11 @@ fn parse_modifier(modifier: &str) -> Option<(Modifier, ModifierState)> {
     // Everything is case-insensitive
     let mut modifier = &modifier.to_uppercase()[..];
     let mut modifier_state = ModifierState::Either;
-    if modifier.starts_with("L") {
-        modifier = remove_first_char(modifier);
+    if modifier.ends_with("_L") {
+        modifier = remove_suffix(modifier);
         modifier_state = ModifierState::Left;
-    } else if modifier.starts_with("R") {
-        modifier = remove_first_char(modifier);
+    } else if modifier.ends_with("_R") {
+        modifier = remove_suffix(modifier);
         modifier_state = ModifierState::Right;
     }
 
@@ -99,8 +99,9 @@ fn parse_modifier(modifier: &str) -> Option<(Modifier, ModifierState)> {
     }
 }
 
-fn remove_first_char(string: &str) -> &str {
+fn remove_suffix(string: &str) -> &str {
     let mut chars = string.chars();
-    chars.next();
+    chars.next_back();
+    chars.next_back();
     chars.as_str()
 }

--- a/src/config/key_press.rs
+++ b/src/config/key_press.rs
@@ -6,10 +6,18 @@ use std::error;
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct KeyPress {
     pub key: Key,
-    pub shift: bool,
-    pub control: bool,
-    pub alt: bool,
-    pub windows: bool,
+    pub shift: ModifierState,
+    pub control: ModifierState,
+    pub alt: ModifierState,
+    pub windows: ModifierState,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum ModifierState {
+    Left,
+    Right,
+    Either,
+    None,
 }
 
 pub enum Modifier {
@@ -32,17 +40,17 @@ impl<'de> Deserialize<'de> for KeyPress {
 fn parse_key_press(input: &str) -> Result<KeyPress, Box<dyn error::Error>> {
     let keys: Vec<&str> = input.split("-").collect();
     if let Some((key, modifiers)) = keys.split_last() {
-        let mut shift = false;
-        let mut control = false;
-        let mut alt = false;
-        let mut windows = false;
+        let mut shift = ModifierState::None;
+        let mut control = ModifierState::None;
+        let mut alt = ModifierState::None;
+        let mut windows = ModifierState::None;
 
         for modifier in modifiers.iter() {
             match parse_modifier(modifier) {
-                Some(Modifier::Shift) => shift = true,
-                Some(Modifier::Control) => control = true,
-                Some(Modifier::Alt) => alt = true,
-                Some(Modifier::Windows) => windows = true,
+                Some((Modifier::Shift, state)) => shift = state,
+                Some((Modifier::Control, state)) => control = state,
+                Some((Modifier::Alt, state)) => alt = state,
+                Some((Modifier::Windows, state)) => windows = state,
                 None => return Err(format!("unknown modifier: {}", modifier).into()),
             }
         }
@@ -60,22 +68,22 @@ fn parse_key_press(input: &str) -> Result<KeyPress, Box<dyn error::Error>> {
     }
 }
 
-fn parse_modifier(modifier: &str) -> Option<Modifier> {
+fn parse_modifier(modifier: &str) -> Option<(Modifier, ModifierState)> {
     // Everything is case-insensitive
     match &modifier.to_uppercase()[..] {
         // Shift
-        "SHIFT" => Some(Modifier::Shift),
+        "SHIFT" => Some((Modifier::Shift, ModifierState::Either)),
         // Control
-        "C" => Some(Modifier::Control),
-        "CTRL" => Some(Modifier::Control),
-        "CONTROL" => Some(Modifier::Control),
+        "C" => Some((Modifier::Control, ModifierState::Either)),
+        "CTRL" => Some((Modifier::Control, ModifierState::Either)),
+        "CONTROL" => Some((Modifier::Control, ModifierState::Either)),
         // Alt
-        "M" => Some(Modifier::Alt),
-        "ALT" => Some(Modifier::Alt),
+        "M" => Some((Modifier::Alt, ModifierState::Either)),
+        "ALT" => Some((Modifier::Alt, ModifierState::Either)),
         // Windows
-        "SUPER" => Some(Modifier::Windows),
-        "WIN" => Some(Modifier::Windows),
-        "WINDOWS" => Some(Modifier::Windows),
+        "SUPER" => Some((Modifier::Windows, ModifierState::Either)),
+        "WIN" => Some((Modifier::Windows, ModifierState::Either)),
+        "WINDOWS" => Some((Modifier::Windows, ModifierState::Either)),
         // else
         _ => None,
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -66,9 +66,9 @@ fn test_keymap_lr_modifiers() {
     keymap:
       - name: Global
         remap:
-          LAlt-Enter: RCtrl-Enter
+          Alt_L-Enter: Ctrl_L-Enter
       - remap:
-          RM-S: LC-S
+          M_R-S: C_L-S
     "})
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -56,7 +56,19 @@ fn test_keymap_basic() {
         remap:
           Alt-Enter: Ctrl-Enter
       - remap:
-          Alt-S: Ctrl-S
+          M-S: C-S
+    "})
+}
+
+#[test]
+fn test_keymap_lr_modifiers() {
+    assert_parse(indoc! {"
+    keymap:
+      - name: Global
+        remap:
+          LAlt-Enter: RCtrl-Enter
+      - remap:
+          RM-S: LC-S
     "})
 }
 


### PR DESCRIPTION
## Example
```yml
keymap:
  - remap:
      Ctrl_L-c: Esc
      Ctrl_R-c: Ctrl-c
      # This also works:
      Ctrl_R-c: Ctrl_R-c
```