### PR TITLE
Only use feature-related dependencies when needed.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "1.11", features = ["chrono"] }
 serde_yaml = "0.8"
-swayipc = "2.7.2"
-x11_rs = { package = "x11", version = "2.19.1", features = ["xlib"] }
-zbus = "1.9.2"
+zbus = { version = "1.9.2", optional = true }
+x11_rs = { package = "x11", version = "2.19.1", features = ["xlib"], optional = true }
+swayipc = { version = "2.7.2", optional = true }
 
 [features]
-gnome = []
-sway = []
-x11 = []
+gnome = ["zbus"]
+sway = ["swayipc"]
+x11 = ["x11_rs"]


### PR DESCRIPTION
This help xremap only pull x11_rs/swayipc/zbus only when corresponding feature flags is used.