### PR TITLE
Support executing commands on press/release events

### DIFF
--- a/src/config/key_action.rs
+++ b/src/config/key_action.rs
@@ -11,6 +11,7 @@ pub enum KeyAction {
     #[serde(deserialize_with = "deserialize_key")]
     Key(Key),
     MultiPurposeKey(MultiPurposeKey),
+    CommandKey(CommandKey),
 }
 
 #[serde_as]
@@ -23,6 +24,12 @@ pub struct MultiPurposeKey {
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(default = "default_alone_timeout", rename = "alone_timeout_millis")]
     pub alone_timeout: Duration,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CommandKey {
+    pub press: Vec<String>,
+    pub release: Vec<String>,
 }
 
 fn default_alone_timeout() -> Duration {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -123,6 +123,14 @@ impl EventHandler {
                 // fallthrough on state discrepancy
                 vec![(key, value)]
             }
+            KeyAction::CommandKey(command_key) => {
+                if value == PRESS {
+                    self.run_command(command_key.press)
+                } else if value == RELEASE {
+                    self.run_command(command_key.release)
+                }
+                vec![]
+            }
         }
     }
 


### PR DESCRIPTION
Close https://github.com/k0kubun/xremap/issues/72

## Example
```yml
modmap:
  - remap:
      Win_R:
        press: ["xdotool", "mousemove", "0", "3600"]
        release: ["xdotool", "mousemove", "0", "0"]
```