### PR TITLE
Support executing commands on press/release events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * Application-specific remapping. Even if it's not supported by your application, xremap can.
 * Automatically remap newly connected devices by starting xremap with `--watch`.
 * Support [Emacs-like key remapping](example/emacs.yml), including the mark mode.
+* Trigger commands on key press/release events.
 
 ## Installation
 
@@ -153,11 +154,14 @@ modmap:
   - name: Name # Optional
     remap: # Required
       KEY_XXX: KEY_YYY # Required
-      # or
       KEY_XXX:
         held: KEY_YYY # Required
         alone: KEY_ZZZ # Required
         alone_timeout_millis: 1000 # Optional
+      # Trigger `keymap` action on key press/release events.
+      KEY_XXX:
+        press: { launch: ["xdotool", "mousemove", "0", "7200"] } # Required
+        release: { launch: ["xdotool", "mousemove", "0", "0"] } # Required
     application: # Optional
       not: [Application, ...]
       # or
@@ -180,25 +184,25 @@ before any other key is pressed. Otherwise it's considered `held`.
 keymap:
   - name: Name # Optional
     remap: # Required
-      # key press -> key press
+      # Key press -> Key press
       MOD1-KEY_XXX: MOD2-KEY_YYY
-      # sequence (MOD1-KEY_XXX, MOD2-KEY_YYY) -> key press (MOD3-KEY_ZZZ)
+      # Sequence (MOD1-KEY_XXX, MOD2-KEY_YYY) -> Key press (MOD3-KEY_ZZZ)
       MOD1-KEY_XXX:
         remap:
           MOD2-KEY_YYY: MOD3-KEY_ZZZ
         timeout_millis: 200 # Optional. No timeout by default.
-      # key press (MOD1-KEY_XXX) -> sequence (MOD2-KEY_YYY, MOD3-KEY_ZZZ)
+      # Key press (MOD1-KEY_XXX) -> Sequence (MOD2-KEY_YYY, MOD3-KEY_ZZZ)
       MOD1-KEY_XXX: [MOD2-KEY_YYY, MOD3-KEY_ZZZ]
-      # execute a command
+      # Execute a command
       MOD1-KEY_XXX:
         launch: ["bash", "-c", "echo hello > /tmp/test"]
-      # let `with_mark` also press a Shift key (useful for Emacs emulation)
+      # Let `with_mark` also press a Shift key (useful for Emacs emulation)
       MOD1-KEY_XXX: { set_mark: true } # use { set_mark: false } to disable it
-      # also press Shift only when { set_mark: true } is used before
+      # Also press Shift only when { set_mark: true } is used before
       MOD1-KEY_XXX: { with_mark: MOD2-KEY_YYY }
-      # the next key press will ignore keymap
+      # The next key press will ignore keymap
       MOD1-KEY_XXX: { escape_next_key: true }
-      # set mode to configure Vim-like modal remapping
+      # Set mode to configure Vim-like modal remapping
       MOD1-KEY_XXX: { set_mode: default }
     application: # Optional
       not: [Application, ...]

--- a/src/config/key_action.rs
+++ b/src/config/key_action.rs
@@ -1,8 +1,10 @@
 use crate::config::key::deserialize_key;
 use evdev::Key;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_with::{serde_as, DurationMilliSeconds};
 use std::time::Duration;
+
+use super::action::{Action, Actions};
 
 // Values in `modmap.remap`
 #[derive(Clone, Debug, Deserialize)]
@@ -11,6 +13,7 @@ pub enum KeyAction {
     #[serde(deserialize_with = "deserialize_key")]
     Key(Key),
     MultiPurposeKey(MultiPurposeKey),
+    PressReleaseKey(PressReleaseKey),
 }
 
 #[serde_as]
@@ -23,6 +26,23 @@ pub struct MultiPurposeKey {
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(default = "default_alone_timeout", rename = "alone_timeout_millis")]
     pub alone_timeout: Duration,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize)]
+pub struct PressReleaseKey {
+    #[serde(deserialize_with = "deserialize_actions")]
+    pub press: Vec<Action>,
+    #[serde(deserialize_with = "deserialize_actions")]
+    pub release: Vec<Action>,
+}
+
+pub fn deserialize_actions<'de, D>(deserializer: D) -> Result<Vec<Action>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let actions = Actions::deserialize(deserializer)?;
+    return Ok(actions.into_vec());
 }
 
 fn default_alone_timeout() -> Duration {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -67,6 +67,17 @@ fn test_modmap_multi_purpose_key() {
 }
 
 #[test]
+fn test_modmap_press_release_key() {
+    assert_parse(indoc! {r#"
+    modmap:
+      - remap:
+          Space:
+            press: { launch: ["wmctrl", "-x", "-a", "code.Code"] }
+            release: { launch: ["wmctrl", "-x", "-a", "nocturn.Nocturn"] }
+    "#})
+}
+
+#[test]
 fn test_keymap_basic() {
     assert_parse(indoc! {"
     keymap:


### PR DESCRIPTION
Close https://github.com/k0kubun/xremap/issues/72

```yml
modmap:
  - remap:
      Win_R:
        press: { launch: ["xdotool", "mousemove", "0", "7200"] }
        release: { launch: ["xdotool", "mousemove", "0", "0"] }
```

`press`/`release` could use any `keymap` actions, including `launch`.