### PR TITLE
Support modal remapping

### DIFF
--- a/src/config/action.rs
+++ b/src/config/action.rs
@@ -16,6 +16,8 @@ pub enum Action {
     Remap(Remap),
     #[serde(deserialize_with = "deserialize_launch")]
     Launch(Vec<String>),
+    #[serde(deserialize_with = "deserialize_set_mode")]
+    SetMode(String),
     #[serde(deserialize_with = "deserialize_set_mark")]
     SetMark(bool),
     #[serde(deserialize_with = "deserialize_with_mark")]
@@ -46,6 +48,19 @@ where
         }
     }
     Err(de::Error::custom("not a map with a single \"launch\" key"))
+}
+
+fn deserialize_set_mode<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut action = HashMap::<String, String>::deserialize(deserializer)?;
+    if let Some(set) = action.remove("set_mode") {
+        if action.is_empty() {
+            return Ok(set);
+        }
+    }
+    Err(de::Error::custom("not a map with a single \"set_mode\" key"))
 }
 
 fn deserialize_set_mark<'de, D>(deserializer: D) -> Result<bool, D::Error>

--- a/src/config/application.rs
+++ b/src/config/application.rs
@@ -10,7 +10,7 @@ pub struct Application {
     pub not: Option<Vec<String>>,
 }
 
-fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+pub fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,4 +1,5 @@
 use crate::config::action::{Action, Actions};
+use crate::config::application::deserialize_string_or_vec;
 use crate::config::application::Application;
 use crate::config::key_press::{KeyPress, Modifier, ModifierState};
 use serde::{Deserialize, Deserializer};
@@ -12,6 +13,8 @@ pub struct Keymap {
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<KeyPress, Vec<Action>>,
     pub application: Option<Application>,
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub mode: Option<Vec<String>>,
 }
 
 fn deserialize_remap<'de, D>(deserializer: D) -> Result<HashMap<KeyPress, Vec<Action>>, D::Error>

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -25,6 +25,8 @@ pub struct Config {
     pub modmap: Vec<Modmap>,
     #[serde(default = "Vec::new")]
     pub keymap: Vec<Keymap>,
+    #[serde(default = "default_mode")]
+    pub default_mode: String,
     #[serde(skip)]
     pub modify_time: Option<SystemTime>,
 }
@@ -48,4 +50,8 @@ pub fn config_watcher(watch: bool, file: &Path) -> anyhow::Result<Option<Inotify
     } else {
         Ok(None)
     }
+}
+
+fn default_mode() -> String {
+    "default".to_string()
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -128,6 +128,24 @@ fn test_keymap_launch() {
 }
 
 #[test]
+fn test_keymap_mode() {
+    assert_parse(indoc! {"
+    default_mode: insert
+    keymap:
+      - mode: insert
+        remap:
+          Esc: { set_mode: normal }
+      - mode: normal
+        remap:
+          i: { set_mode: insert }
+          h: Left
+          j: Down
+          k: Up
+          l: Right
+    "})
+}
+
+#[test]
 fn test_keymap_mark() {
     assert_parse(indoc! {"
     keymap:

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> anyhow::Result<()> {
     };
     let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
     let timer_fd = timer.as_raw_fd();
-    let mut handler = EventHandler::new(output_device, timer);
+    let mut handler = EventHandler::new(output_device, timer, &config.default_mode);
     let mut input_devices = match get_input_devices(&device_filter, &ignore_filter, watch_devices) {
         Ok(input_devices) => input_devices,
         Err(e) => bail!("Failed to prepare input devices: {}", e),


### PR DESCRIPTION
Close #89

## Example

```yml
default_mode: insert
keymap:
  - mode: insert
    remap:
      Esc: { set_mode: normal }
  - mode: normal
    remap:
      i: { set_mode: insert }
      h: Left
      j: Down
      k: Up
      l: Right
```