### PR TITLE
Use xremap's original extension to talk to GNOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,43 +51,9 @@ Then run:
 sudo xremap config.yml
 ```
 
-### Dynamic binding
-
-Xremap supports application-specific key remapping.
-
-While Xremap uses `evdev` and `uinput` for key remapping, which is a lower layer than X11 and Wayland,
-Xremap also uses X11 or Wayland compositor-specific protocols to support `application` config.
-If you use this feature, make sure you use the appropriate binary for your platform,
-and follow one of the following options to make it work.
-
 <details>
-<summary>Option 1: Allow root to talk to the compositor</summary>
+<summary>If you want to run xremap without sudo, click here.</summary>
 
-If you use `sudo xremap`, root user usually cannot interact with the compositor for your normal user.
-You may need to allow it as follows:
-
-#### X11
-
-You may need to run `xhost +SI:localuser:root` if you see `No protocol specified`.
-
-#### GNOME Wayland
-
-Update `/usr/share/dbus-1/session.conf` as follows, and reboot your machine.
-
-```diff
-   <policy context="default">
-+    <allow user="root"/>
-     <!-- Allow everything to be sent -->
-     <allow send_destination="*" eavesdrop="true"/>
-     <!-- Allow everything to be received -->
-```
-
-</details>
-
-<details>
-<summary>Option 2: Run xremap without sudo</summary>
-
-Alternatively, you could run `xremap` without sudo to solve the problem.
 To do so, your normal user should be able to use `evdev` and `uinput` without sudo.
 In Ubuntu, this can be configured by running the following commands and rebooting your machine.
 
@@ -99,8 +65,33 @@ echo 'KERNEL=="uinput", GROUP="input"' | sudo tee /etc/udev/rules.d/input.rules
 In other platforms, you might need to create an `input` group first
 and run `echo 'KERNEL=="event*", NAME="input/%k", MODE="660", GROUP="input"' | sudo tee /etc/udev/rules.d/input.rules` as well.
 
-If you take this path, in some environments, `--watch` may fail to recognize new devices due to temporary permission issues.
-Option 1 might be more useful in such cases.
+If you do this, in some environments, `--watch` may fail to recognize new devices due to temporary permission issues.
+Using `sudo` might be more useful in such cases.
+
+</details>
+
+See the following instructions for your environment to make `application`-specific remapping work.
+
+### X11
+
+If you use `sudo` to run `xremap`, you may need to run `xhost +SI:localuser:root` if you see `No protocol specified`.
+
+### GNOME Wayland
+
+Install [the GNOME Shell extension for xremap](https://github.com/xremap/xremap-gnome) first.
+
+<details>
+<summary>If you use <code>sudo</code> to run <code>xremap</code>, also click here.</summary>
+
+Update `/usr/share/dbus-1/session.conf` as follows, and reboot your machine.
+
+```diff
+   <policy context="default">
++    <allow user="root"/>
+     <!-- Allow everything to be sent -->
+     <allow send_destination="*" eavesdrop="true"/>
+     <!-- Allow everything to be received -->
+```
 
 </details>
 

--- a/src/client/gnome_client.rs
+++ b/src/client/gnome_client.rs
@@ -31,21 +31,15 @@ impl Client for GnomeClient {
             None => return None,
         };
 
-        let code = "
-            const actor = global.get_window_actors().find(a=>a.meta_window.has_focus()===true)
-            actor && actor.get_meta_window().get_wm_class()
-        ";
         if let Ok(message) = connection.call_method(
             Some("org.gnome.Shell"),
-            "/org/gnome/Shell",
-            Some("org.gnome.Shell"),
-            "Eval",
-            &(code),
+            "/com/k0kubun/Xremap",
+            Some("com.k0kubun.Xremap"),
+            "WMClass",
+            &(),
         ) {
-            if let Ok((_actor, json)) = message.body::<(bool, String)>() {
-                if let Ok(wm_class) = serde_json::from_str::<String>(&json) {
-                    return Some(wm_class);
-                }
+            if let Ok(wm_class) = message.body::<String>() {
+                return Some(wm_class);
             }
         }
         None


### PR DESCRIPTION
Close #88 

## Usage
1. `git clone https://github.com/xremap/xremap-gnome ~/.local/share/gnome-shell/extensions/xremap@k0kubun.com`
2. Restart your GNOME Shell session, e.g. reboot
3. Run `gnome-extensions-app` and enable Xremap
4. The binary built by `cargo build --features gnome` should work on GNOME 40+.