### PR TITLE
Add nix flake

### DIFF
--- a/nix-flake/README.md
+++ b/nix-flake/README.md
@@ -1,0 +1,37 @@
+# What this is
+
+This is a [Nix flake](https://nixos.wiki/wiki/Flakes) that installs and configures [xremap](https://github.com/k0kubun/xremap)
+
+# What is tested in flake
+
+The flake was developed to mostly work in Sway. Thus the following features are tested:
+
+| Scenario | No features | Sway | Gnome | X11 |
+| - | - | - | - | - |
+| Tested? | :heavy_check_mark: | :heavy_check_mark: | :heavy_multiplication_x: | :heavy_multiplication_x: |
+
+# How to use
+
+Add following to your `flake.nix`:
+
+```nix
+{
+    inputs.xremap-flake.url = "github:VTimofeenko/xremap?dir=nix-flake";
+}
+```
+
+And import the `xremap-flake.nixosModules.defalut` module.
+
+Alternatively, flake application can be `nix run` to launch xremap without features.
+
+# Configuration
+
+Following `services.xremap` options are exposed:
+
+* `config` – configuration file for xremap. See [original repo](https://github.com/k0kubun/xremap) for examples.
+* `withSway` – whether to enable Sway support
+* `withSway` – whether to enable Gnome support
+* `package` – which package for xremap to use
+* `userId` – user under which Sway IPC socket runs
+* `deviceName` – the name of the device to be used. To find out the name, you can check `/proc/bus/input/devices`
+* `watch` – whether to watch for new devices

--- a/nix-flake/flake.lock
+++ b/nix-flake/flake.lock
@@ -1,0 +1,79 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1655042882,
+        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1657086189,
+        "narHash": "sha256-wSiZ7wBqke9qCDOyYhAU68HT63iZQWrsxG6NlTfBzto=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e120ef6a5a7d835e19082d037f6a079e836ce8ca",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1657086189,
+        "narHash": "sha256-wSiZ7wBqke9qCDOyYhAU68HT63iZQWrsxG6NlTfBzto=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e120ef6a5a7d835e19082d037f6a079e836ce8ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "xremap": "xremap"
+      }
+    },
+    "xremap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1655872658,
+        "narHash": "sha256-VnG89XFNGfnyAZNsvjL8sR/xOzWXko7JF8gyMv+MU0A=",
+        "owner": "k0kubun",
+        "repo": "xremap",
+        "rev": "38c8485704151aba7a825ff4c03be1f01f60d304",
+        "type": "github"
+      },
+      "original": {
+        "owner": "k0kubun",
+        "ref": "v0.4.4",
+        "repo": "xremap",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix-flake/flake.nix
+++ b/nix-flake/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Flake that configures Xremap, a key remapper for Linux";
+
+  inputs = {
+    # Nixpkgs will be pinned to unstable to get the latest Rust
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Utils for building Rust stuff
+    naersk.url = "github:nmattia/naersk/master";
+    # The Rust source for xremap
+    xremap = {
+      url = "github:k0kubun/xremap?ref=v0.4.4";
+      flake = false;
+    };
+  };
+  outputs = { self, nixpkgs, naersk, xremap }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      naersk-lib = pkgs.callPackage naersk { };
+      package = (import ./overlay xremap naersk-lib pkgs { }).xremap-unwrapped;
+    in
+    {
+      packages."${system}".default = package;
+      apps."${system}".default = {
+        type = "app";
+        program = "${package}/bin/xremap";
+      };
+      # Note, "pkgs" omitted here, so that it plays well with other overlays
+      nixosModules.default = import ./modules xremap naersk-lib;
+      devShells."${system}".default = with pkgs; mkShell {
+        buildInputs = [ cargo rustc rustfmt rustPackages.clippy ];
+        RUST_SRC_PATH = rustPlatform.rustLibSrc;
+      };
+    };
+}

--- a/nix-flake/modules/default.nix
+++ b/nix-flake/modules/default.nix
@@ -1,0 +1,106 @@
+xremap: naersk-lib: { pkgs, config, ... }:
+
+let
+  cfg = config.services.xremap;
+  package = (import ../overlay xremap naersk-lib pkgs { inherit (cfg) withSway withGnome withX11; }).xremap-unwrapped;
+in
+with pkgs.lib;
+{
+  options.services.xremap = {
+    withSway = mkEnableOption "support for Sway";
+    withGnome = mkEnableOption "support for Gnome";
+    withX11 = mkEnableOption "support for X11";
+    package = mkOption {
+      type = types.package;
+      default = package;
+    };
+    config = mkOption {
+      type = types.either types.str types.path;
+      default = "";
+      example = ''
+                modmap:
+                - name: Except Chrome
+                application:
+        not: Google-chrome
+             remap:
+        CapsLock: Esc
+                  keymap:
+                  - name: Emacs binding
+                  application:
+        only: Slack
+              remap:
+              C-b: left
+              C-f: right
+              C-p: up
+              C-n: down
+      '';
+    };
+    userId = mkOption {
+      type = types.int;
+      default = 1000;
+      description = "User ID that would run Sway IPC socket";
+    };
+    deviceName = mkOption {
+      type = types.str;
+      description = "Device name which xremap will hook into";
+    };
+    watch = mkEnableOption "running xremap watching new devices";
+  };
+  config =
+    let
+      userPath = "/run/user/${toString cfg.userId}";
+    in
+    {
+      environment.etc."xremap_config.yml".text = cfg.config;
+      systemd.services.xremap = {
+        description = "xremap";
+        path = [ cfg.package ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          PrivateNetwork = true;
+          MemoryDenyWriteExecute = true;
+          CapabilityBoundingSet = [ "~CAP_SETUID" "~CAP_SETGID" "~CAP_SETPCAP" "~CAP_SYS_ADMIN" "~CAP_SYS_PTRACE" "~CAP_NET_ADMIN" "~CAP_FOWNER" "~CAP_IPC_OWNER" "~CAP_SYS_TIME" "~CAP_KILL" "~CAP_SYS_BOOT" "~CAP_LINUX_IMMUTABLE" "~CAP_IPC_LOCK" "~CAP_SYS_CHROOT" "~CAP_BLOCK_SUSPEND" "~CAP_SYS_PACCT" "~CAP_WAKE_ALARM" "~CAP_AUDIT_WRITE" "~CAP_AUDIT_CONTROL" "~CAP_AUDIT_READ" "CAP_DAC_READ_SEARCH" "CAP_DAC_OVERRIDE" ];
+          SystemCallArchitectures = [ "native" ];
+          RestrictRealtime = true;
+          SystemCallFilter = map (x: "~@${x}") [ "clock" "debug" "module" "reboot" "swap" "cpu-emulation" "obsolete" "privileged" "resources" ];
+          LockPersonality = true;
+          UMask = "077";
+          IPAddressDeny = [ "0.0.0.0/0" "::/0" ];
+          # ProtectClock adds to DeviceAllow, which does not seem to work with xremap since it tries to enumerate all /dev/input devices
+          # ProtectClock = true;
+          # DeviceAllow = [ "/dev/input/event24" ];
+          ProtectHostname = true;
+          # Does not work, the service cannot locate sway socket
+          # PrivateUsers = true;
+          RestrictAddressFamilies = "AF_UNIX";
+          RestrictNamespaces = true;
+          # RestrictNamespaces = ["~CLONE_NEWUSER" "~CLONE_NEWIPC" "~CLONE_NEWNET" "~CLONE_NEWNS" "~CLONE_NEWPID"];
+          # ProtectClock = true;
+          # Need 'tmpfs' here so that the socket may be actually bind-mounted through Bind*Paths
+          ProtectHome = "tmpfs";
+          # This is needed, otherwise xremap cannot read from sway socket
+          BindReadOnlyPaths = [ userPath ];
+          # Sway socket gets generated as $XDG_RUNTIME_DIR/sway-ipc.$UID.$SWAY_PID
+          # Hacky way to allow sway socket
+          # Systemd does not support wildcards :(
+          InaccessiblePaths = map (x: "-${userPath}/${x}") [ "app" "bus" "dbus-1" ".dbus-proxy" "dconf" "env-vars" ".flatpak" ".flatpak-helper" "gnupg" "pipewire-0" "pipewire-0.lock" "pulse" "systemd" "tmux-${toString cfg.userId}" "wayland-1" "wayland-1.lock" ];
+          PrivateTmp = true;
+          ProtectKernelLogs = true;
+          # Does not work, running as root
+          # ProtectProc = true;
+          # SystemCallFilter = "~@clock";
+          NoNewPrivileges = true;
+          ProtectSystem = "strict";
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          RestrictSUIDSGID = true;
+          # End of hardening
+          ExecStart = ''
+            ${cfg.package}/bin/xremap --device "${cfg.deviceName}" ${if cfg.watch then "--watch" else ""} /etc/xremap_config.yml
+          '';
+          Nice = -20;
+        };
+      };
+    };
+}

--- a/nix-flake/overlay/default.nix
+++ b/nix-flake/overlay/default.nix
@@ -1,0 +1,17 @@
+# Overlay file that contains the definition of building a package
+xremap: naersk-lib: pkgs: { withSway ? false, withGnome ? false, withX11 ? false }:
+{
+  xremap-unwrapped = naersk-lib.buildPackage rec {
+    # Used in this context, "xremap" will translate to the path in the store where the source was downloaded
+    root = xremap;
+    cargoBuildOptions = with pkgs.lib;
+      (x:
+        x ++ optional (builtins.any (x: x == true) [ withSway withGnome ]) "--features \"${ if withSway then "sway" else ""} ${if withGnome then "gnome" else ""} ${ if withX11 then "x11" else ""}\""
+      );
+    # The following two options are for introspection to be able to see if sway/gnome were actually pulled in
+    # To see that - visually inspect the deps directory inside result/target/ and check for swayipc/zbus
+    # See cargo.toml for feature-specific deps
+    /* copyTarget = true; */
+    /* compressTarget = false; */
+  };
+}


### PR DESCRIPTION
This commit adds a Nix flake to allow easy installation of xremap on Nixos.

It comes with a NixOS module that includes a locked down systemd service and exposes several configuration options for xremap.