### PR TITLE
Support regex for application names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,9 +714,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ryu"
@@ -1099,6 +1099,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nix 0.24.2",
+ "regex",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ indoc = "1.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
 nix = "0.24.2"
+regex = "1.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "2.0", features = ["chrono"] }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -33,6 +33,24 @@ fn test_modmap_application() {
 }
 
 #[test]
+fn test_modmap_application_regex() {
+    assert_parse(indoc! {r"
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        application:
+          not:
+            - /^Minecraft/
+            - /^Minecraft\//
+            - /^Minecraft\d/
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: /^Miencraft\\/
+    "})
+}
+
+#[test]
 fn test_modmap_multi_purpose_key() {
     assert_parse(indoc! {"
     modmap:

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -436,10 +436,10 @@ impl EventHandler {
 
         if let Some(application) = &self.application_cache {
             if let Some(application_only) = &application_matcher.only {
-                return application_only.contains(application);
+                return application_only.iter().any(|m| m.matches(application));
             }
             if let Some(application_not) = &application_matcher.not {
-                return !application_not.contains(application);
+                return application_not.iter().all(|m| !m.matches(application));
             }
         }
         false


### PR DESCRIPTION
I'd like to map left Ctrl as Esc when pressed alone unless I'm in
Minecraft. Since Minecraft adds its version number to the window class
name, e.g. `Minecraft* 1.19.2` (and I think I have an `*` cos I use
mods), it's nice to be able to use regular expressions.

Thanks for this great application btw!