### PR TITLE
Add --mouse command line option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,19 @@ jobs:
       - name: cargo fmt
         run: cargo fmt -- --check
 
+  clippy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: cargo clippy
+        run: cargo clippy --locked --tests -- -D warnings
+
   test:
     runs-on: ubuntu-18.04
     steps:

--- a/src/config/action.rs
+++ b/src/config/action.rs
@@ -31,10 +31,10 @@ where
     D: Deserializer<'de>,
 {
     let action = RemapActions::deserialize(deserializer)?;
-    return Ok(Remap {
+    Ok(Remap {
         remap: action.remap.into_iter().map(|(k, v)| (k, v.into_vec())).collect(),
-        timeout: action.timeout_millis.map(|ms| Duration::from_millis(ms)),
-    });
+        timeout: action.timeout_millis.map(Duration::from_millis),
+    })
 }
 
 fn deserialize_launch<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -178,6 +178,6 @@ fn test_keymap_mark() {
 fn assert_parse(yaml: &str) {
     let result: Result<Config, Error> = serde_yaml::from_str(yaml);
     if let Err(e) = result {
-        assert!(false, "{}", e)
+        panic!("{}", e)
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -194,6 +194,9 @@ impl InputDevice {
 
 impl InputDevice {
     pub fn is_input_device(&self, device_filter: &[String], ignore_filter: &[String], mouse: bool) -> bool {
+        if self.device_name() == Self::current_name() {
+            return false;
+        }
         (if device_filter.is_empty() {
             self.is_keyboard() || (mouse && self.is_mouse())
         } else {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -145,7 +145,7 @@ impl EventHandler {
             self.pressed_keys.insert(key, event.0);
         } else {
             if let Some(original_key) = self.pressed_keys.get(&key) {
-                events[0].0 = original_key.clone();
+                events[0].0 = *original_key;
             }
             if value == RELEASE {
                 self.pressed_keys.remove(&key);
@@ -268,7 +268,7 @@ impl EventHandler {
                     let expiration = Expiration::OneShot(TimeSpec::from_duration(timeout));
                     self.override_timer.unset()?;
                     self.override_timer.set(expiration, TimerSetTimeFlags::empty())?;
-                    self.override_timeout_key = Some(key.clone());
+                    self.override_timeout_key = Some(*key);
                 }
             }
             Action::Launch(command) => self.run_command(command.clone()),


### PR DESCRIPTION
I mapped control to ESC only when pressed alone. When held, I expect the
key to work like a regular control key, and one thing I often do is
clicking on things while holding it (selecting files in file manager,
opening links in new tabs, etc.).

This is a quite common pattern especially for Vim users. And considering
other remapping programs such as `xcape` (X11) and Karabiner Elements
(macOS) capture mice by default, I reckon it's handy to have a `--mouse`
option to achieve this. `--device` can do the same but since people
carry laptops around and either use touchpad or connect to different
mice, `--mouse` still offers a little convenience.

- Add --mouse option to select mice by default
- Add cargo clippy to GH Actions
- Fix clippy warnings

The clippy commits are not relevant to this new option. Let me know if
you want me to submit them in a different PR or just remove them.
