### PR TITLE
Support overriding timeout_key on nested remap

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,7 +6,7 @@ pub mod key_press;
 pub mod keymap;
 mod modmap;
 
-mod remap;
+pub mod remap;
 #[cfg(test)]
 mod tests;
 

--- a/src/config/remap.rs
+++ b/src/config/remap.rs
@@ -1,10 +1,24 @@
+use evdev::Key;
+use serde::Deserialize;
+
 use crate::config::action::Action;
 use crate::config::key_press::KeyPress;
 use std::collections::HashMap;
 use std::time::Duration;
 
+use super::action::Actions;
+
 #[derive(Clone, Debug)]
 pub struct Remap {
     pub remap: HashMap<KeyPress, Vec<Action>>,
     pub timeout: Option<Duration>,
+    pub timeout_key: Option<Key>,
+}
+
+// USed only for deserialization
+#[derive(Debug, Deserialize)]
+pub struct RemapActions {
+    pub remap: HashMap<KeyPress, Actions>,
+    pub timeout_millis: Option<u64>,
+    pub timeout_key: Option<String>,
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -139,6 +139,7 @@ fn test_keymap_remap() {
               C-s:
                 remap:
                   x: C-z
+            timeout_key: Down
             timeout_millis: 1000
     "})
 }


### PR DESCRIPTION
Close #128

## Example

```yml
keymap:
  - remap:
      J:
        remap:
          K: Esc
        timeout_key: Down
        timeout_millis: 150
```

`j` alone outputs ↓ and `jk` outputs Esc.