### PR TITLE
Support logical modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,12 @@ is supported only in `modmap` since `keymap` handles modifier keys differently.
 modmap:
   - name: Name # Optional
     remap: # Required
+      # Replace a key with another
       KEY_XXX: KEY_YYY # Required
+      # Make it a logical modifier key
+      KEY_XXX:
+        modifier: true # Required
+      # Dispatch different keys depending on whether you hold it or press it alone
       KEY_XXX:
         held: KEY_YYY # Required
         alone: KEY_ZZZ # Required
@@ -225,6 +230,8 @@ For the `MOD1-` part, the following prefixes can be used (also case-insensitive)
 You can use multiple prefixes like `C-M-Shift-a`.
 You may also suffix them with `_L` or `_R` (case-insensitive) so that
 remapping is triggered only on a left or right modifier, e.g. `Ctrl_L-a`.
+
+If you set `modifier: true` in `modmap`, you can use it in the `MOD1-` part too.
 
 ### application
 

--- a/src/config/key_action.rs
+++ b/src/config/key_action.rs
@@ -12,8 +12,14 @@ use super::action::{Action, Actions};
 pub enum KeyAction {
     #[serde(deserialize_with = "deserialize_key")]
     Key(Key),
+    ModifierKey(ModifierKey),
     MultiPurposeKey(MultiPurposeKey),
     PressReleaseKey(PressReleaseKey),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ModifierKey {
+    pub modifier: bool,
 }
 
 #[serde_as]
@@ -28,7 +34,6 @@ pub struct MultiPurposeKey {
     pub alone_timeout: Duration,
 }
 
-#[serde_as]
 #[derive(Clone, Debug, Deserialize)]
 pub struct PressReleaseKey {
     #[serde(deserialize_with = "deserialize_actions")]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,7 +1,7 @@
 use crate::client::{build_client, WMClient};
 use crate::config::action::Action;
 use crate::config::application::Application;
-use crate::config::key_action::{KeyAction, MultiPurposeKey, PressReleaseKey};
+use crate::config::key_action::{KeyAction, ModifierKey, MultiPurposeKey, PressReleaseKey};
 use crate::config::key_press::{KeyPress, Modifier};
 use crate::config::keymap::{build_override_table, OverrideEntry};
 use crate::config::remap::Remap;
@@ -162,6 +162,17 @@ impl EventHandler {
     ) -> Result<Vec<(Key, i32)>, Box<dyn Error>> {
         let keys = match key_action {
             KeyAction::Key(modmap_key) => vec![(modmap_key, value)],
+            KeyAction::ModifierKey(ModifierKey { modifier }) => {
+                if modifier {
+                    if value == PRESS {
+                        self.modifiers.insert(key);
+                    } else if value == RELEASE {
+                        self.modifiers.remove(&key);
+                    }
+                }
+                // Process this key only in xremap
+                vec![]
+            }
             KeyAction::MultiPurposeKey(MultiPurposeKey {
                 held,
                 alone,


### PR DESCRIPTION
Close https://github.com/k0kubun/xremap/issues/124

## Example

```yml
modmap:
  CapsLock: { modifier: true }
keymap:
  CapsLock-i: Up
  CapsLock-j: Left
  CapsLock-k: Down
  CapsLock-l: Right
```