### PR TITLE
Add TAG+="uaccess" in the udev's rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In Ubuntu, this can be configured by running the following commands and rebootin
 
 ```bash
 sudo gpasswd -a YOUR_USER input
-echo 'KERNEL=="uinput", GROUP="input"' | sudo tee /etc/udev/rules.d/input.rules
+echo 'KERNEL=="uinput", GROUP="input", TAG+="uaccess"' | sudo tee /etc/udev/rules.d/input.rules
 ```
 
 #### Arch Linux


### PR DESCRIPTION
As above, on OpenSUSE the udev rule doesn't work unless one appends `TAG+="uaccess"` that basically means granting access to `uinput` to logged in users.