### PR TITLE
Add support for scrollwheel events

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -34,10 +34,11 @@ impl MappableEvent {
 
     pub fn from(raw: InputEvent) -> Option<Self> {
         match raw.kind() {
-            InputEventKind::Key(key) => {
-                Some(Self { key, value: raw.value(), raw })
-            },
-            
+            InputEventKind::Key(key) => Some(Self {
+                key,
+                value: raw.value(),
+                raw,
+            }),
             // Scrollwheel events are treated as if they were SCROLLUP/SCROLLDOWN keypresses,
             // but we emit the original event if it doesn't get remapped.
             InputEventKind::RelAxis(RelativeAxisType::REL_WHEEL) => {
@@ -46,11 +47,11 @@ impl MappableEvent {
                     -1 => Key::KEY_SCROLLDOWN,
                     other => {
                         debug!("Unknown scroll value: {}", other);
-                        return None
+                        return None;
                     }
                 };
                 Some(Self { key, value: PRESS, raw })
-            },
+            }
             _ => None,
         }
     }
@@ -205,7 +206,7 @@ impl EventHandler {
     fn dispatch_keys(
         &mut self,
         key_action: KeyAction,
-        event: MappableEvent
+        event: MappableEvent,
     ) -> Result<Vec<MappableEvent>, Box<dyn Error>> {
         let keys = match key_action {
             KeyAction::Key(modmap_key) => vec![MappableEvent::new(modmap_key, event.value)],
@@ -586,10 +587,16 @@ impl MultiPurposeKeyState {
         if let Some(alone_timeout_at) = &self.alone_timeout_at {
             if Instant::now() < *alone_timeout_at {
                 // dispatch the delayed press and this release
-                vec![MappableEvent::new(self.alone, PRESS), MappableEvent::new(self.alone, RELEASE)]
+                vec![
+                    MappableEvent::new(self.alone, PRESS),
+                    MappableEvent::new(self.alone, RELEASE),
+                ]
             } else {
                 // too late. dispatch the held key
-                vec![MappableEvent::new(self.held, PRESS), MappableEvent::new(self.held, RELEASE)]
+                vec![
+                    MappableEvent::new(self.held, PRESS),
+                    MappableEvent::new(self.held, RELEASE),
+                ]
             }
         } else {
             vec![MappableEvent::new(self.held, RELEASE)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use clap::{AppSettings, ArgEnum, IntoApp, Parser};
 use clap_complete::Shell;
 use config::{config_watcher, load_config};
 use device::InputDevice;
-use evdev::EventType;
 use nix::libc::ENODEV;
 use nix::sys::inotify::{AddWatchFlags, Inotify, InotifyEvent};
 use nix::sys::select::select;
@@ -207,13 +206,9 @@ fn handle_input_events(
         Err((_, error)) => Err(error).context("Error fetching input events"),
         Ok(events) => {
             for event in events {
-                if event.event_type() == EventType::KEY {
-                    handler
-                        .on_event(event, config)
-                        .map_err(|e| anyhow!("Failed handling {event:?}:\n  {e:?}"))?;
-                } else {
-                    handler.send_event(event)?;
-                }
+                handler
+                    .on_event(event, config)
+                    .map_err(|e| anyhow!("Failed handling {event:?}:\n  {e:?}"))?;
             }
             Ok(true)
         }


### PR DESCRIPTION
As discussed in #180 , this is option (2). It's a slightly noisy diff because everything that as previously `(key, value)` has become a `MappableEvent`, to also carry around the original event.

The main logic change is that `main` always calls on_event, and then `event_handler` internally figures out whether it's a mappable event or whether to simply emit it.