### PR TITLE
Adds RELATIVE event catcher

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -2,13 +2,17 @@ use std::time::Duration;
 
 use evdev::InputEvent;
 
-use crate::event::KeyEvent;
+use crate::event::{KeyEvent, RelativeEvent};
 
 // Input to ActionDispatcher. This should only contain things that are easily testable.
 #[derive(Debug)]
 pub enum Action {
     // InputEvent (EventType::KEY) sent to evdev
     KeyEvent(KeyEvent),
+    // InputEvent (EventType::RELATIVE, NOT mouse movement events) sent to evdev
+    RelativeEvent(RelativeEvent),
+    // InputEvent (EventType::RELATIVE, ONLY mouse movement events) sent to evdev
+    MouseMovementEvent(RelativeEvent),
     // InputEvent of any event types. It's discouraged to use this for testing because
     // we don't have full control over timeval and it's not pattern-matching friendly.
     InputEvent(InputEvent),

--- a/src/action.rs
+++ b/src/action.rs
@@ -11,10 +11,8 @@ pub enum Action {
     KeyEvent(KeyEvent),
     // InputEvent (EventType::RELATIVE, NOT mouse movement events) sent to evdev
     RelativeEvent(RelativeEvent),
-    // InputEvent (EventType::RELATIVE, ONLY mouse movement events) sent to evdev
-    MouseMovementEvent(RelativeEvent),
-    // InputEvent (EventType::RELATIVE) a collection of mouse movement events sent to evdev
-    MouseMouvementEventCollection(Vec<RelativeEvent>),
+    // InputEvent (EventType::RELATIVE, ONLY mouse movement events) a collection of mouse movement sent to evdev
+    MouseMovementEventCollection(Vec<RelativeEvent>),
     // InputEvent of any event types. It's discouraged to use this for testing because
     // we don't have full control over timeval and it's not pattern-matching friendly.
     InputEvent(InputEvent),

--- a/src/action.rs
+++ b/src/action.rs
@@ -13,6 +13,8 @@ pub enum Action {
     RelativeEvent(RelativeEvent),
     // InputEvent (EventType::RELATIVE, ONLY mouse movement events) sent to evdev
     MouseMovementEvent(RelativeEvent),
+    // InputEvent (EventType::RELATIVE) a collection of mouse movement events sent to evdev
+    MouseMouvementEventCollection(Vec<RelativeEvent>),
     // InputEvent of any event types. It's discouraged to use this for testing because
     // we don't have full control over timeval and it's not pattern-matching friendly.
     InputEvent(InputEvent),

--- a/src/action_dispatcher.rs
+++ b/src/action_dispatcher.rs
@@ -8,6 +8,7 @@ use nix::sys::signal;
 use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet};
 use std::process::{exit, Command, Stdio};
 
+use crate::event::RelativeEvent;
 use crate::{action::Action, event::KeyEvent};
 
 pub struct ActionDispatcher {
@@ -26,12 +27,42 @@ impl ActionDispatcher {
     }
 
     // Execute Actions created by EventHandler. This should be the only public method of ActionDispatcher.
-    pub fn on_action(&mut self, action: Action) -> anyhow::Result<()> {
-        match action {
-            Action::KeyEvent(key_event) => self.on_key_event(key_event)?,
-            Action::InputEvent(event) => self.send_event(event)?,
-            Action::Command(command) => self.run_command(command),
-            Action::Delay(duration) => thread::sleep(duration),
+    pub fn on_action(&mut self, actions: Vec<Action>) -> anyhow::Result<()> {
+        //vector to collect all mouse movement events
+        let mut mouse_movement_actions: Vec<InputEvent> = Vec::new();
+        for action in actions {
+            match action {
+                Action::KeyEvent(key_event) => self.on_key_event(key_event)?,
+                Action::RelativeEvent(relative_event) => self.on_relative_event(relative_event)?,
+                Action::MouseMovementEvent(mouse_movement_event) => {
+                    //collecting mouse movement events, to send them all in a single batch.
+                    mouse_movement_actions.push(InputEvent::new_now(
+                        EventType::RELATIVE,
+                        mouse_movement_event.code,
+                        mouse_movement_event.value,
+                    ));
+                }
+
+                Action::InputEvent(event) => self.send_event(event)?,
+                Action::Command(command) => self.run_command(command),
+                Action::Delay(duration) => thread::sleep(duration),
+            }
+        }
+
+        if mouse_movement_actions.len() != 0 {
+            //Sending all mouse movement events at once, unseparated by synchronization events.
+            self.send_mousemovement_event_batch(mouse_movement_actions)?;
+
+            //Mouse movement events need to be sent all at once because they would otherwise be separated by a synchronization event¹,
+            //which the OS handles differently from two unseparated mouse movement events.
+            //For example,
+            //a REL_X event², followed by a SYNCHRONIZATION event, followed by a REL_Y event³, followed by a SYNCHRONIZATION event,
+            //will move the mouse cursor by a different amount than
+            //a REL_X event followed by a REL_Y event followed by a SYNCHRONIZATION event.
+
+            //¹Because Xremap usually sends events one by one through evdev's "emit" function, which adds a synchronization event during each call.
+            //²Mouse movement along the X (horizontal) axis.
+            //³Mouse movement along the Y (vertical) axis.
         }
         Ok(())
     }
@@ -39,6 +70,16 @@ impl ActionDispatcher {
     fn on_key_event(&mut self, event: KeyEvent) -> std::io::Result<()> {
         let event = InputEvent::new_now(EventType::KEY, event.code(), event.value());
         self.send_event(event)
+    }
+
+    fn on_relative_event(&mut self, event: RelativeEvent) -> std::io::Result<()> {
+        let event = InputEvent::new_now(EventType::RELATIVE, event.code, event.value);
+        self.send_event(event)
+    }
+
+    //a function that takes mouse movement events to send in a single batch, unseparated by synchronization events.
+    pub fn send_mousemovement_event_batch(&mut self, eventbatch: Vec<InputEvent>) -> std::io::Result<()> {
+        self.device.emit(&eventbatch)
     }
 
     fn send_event(&mut self, event: InputEvent) -> std::io::Result<()> {

--- a/src/action_dispatcher.rs
+++ b/src/action_dispatcher.rs
@@ -31,23 +31,20 @@ impl ActionDispatcher {
         match action {
             Action::KeyEvent(key_event) => self.on_key_event(key_event)?,
             Action::RelativeEvent(relative_event) => self.on_relative_event(relative_event)?,
-            Action::MouseMovementEvent(_) => {
-                //This should not be reachable, since mouse movement events should collected
-            }
-            Action::MouseMouvementEventCollection(mouse_movement_events) => {
-                //Sending all mouse movement events at once, unseparated by synchronization events.
+            Action::MouseMovementEventCollection(mouse_movement_events) => {
+                // Sending all mouse movement events at once, unseparated by synchronization events.
                 self.send_mousemovement_event_batch(mouse_movement_events)?;
 
-                //Mouse movement events need to be sent all at once because they would otherwise be separated by a synchronization event¹,
-                //which the OS handles differently from two unseparated mouse movement events.
-                //For example,
-                //a REL_X event², followed by a SYNCHRONIZATION event, followed by a REL_Y event³, followed by a SYNCHRONIZATION event,
-                //will move the mouse cursor by a different amount than
-                //a REL_X event followed by a REL_Y event followed by a SYNCHRONIZATION event.
+                // Mouse movement events need to be sent all at once because they would otherwise be separated by a synchronization event¹,
+                // which the OS handles differently from two unseparated mouse movement events.
+                // For example,
+                // a REL_X event², followed by a SYNCHRONIZATION event, followed by a REL_Y event³, followed by a SYNCHRONIZATION event,
+                // will move the mouse cursor by a different amount than
+                // a REL_X event followed by a REL_Y event followed by a SYNCHRONIZATION event.
 
-                //¹Because Xremap usually sends events one by one through evdev's "emit" function, which adds a synchronization event during each call.
-                //²Mouse movement along the X (horizontal) axis.
-                //³Mouse movement along the Y (vertical) axis.
+                // ¹Because Xremap usually sends events one by one through evdev's "emit" function, which adds a synchronization event during each call.
+                // ²Mouse movement along the X (horizontal) axis.
+                // ³Mouse movement along the Y (vertical) axis.
             }
 
             Action::InputEvent(event) => self.send_event(event)?,
@@ -67,7 +64,7 @@ impl ActionDispatcher {
         self.send_event(event)
     }
 
-    //a function that takes mouse movement events to send in a single batch, unseparated by synchronization events.
+    // a function that takes mouse movement events to send in a single batch, unseparated by synchronization events.
     fn send_mousemovement_event_batch(&mut self, eventbatch: Vec<RelativeEvent>) -> std::io::Result<()> {
         let mut mousemovementbatch: Vec<InputEvent> = Vec::new();
         for mouse_movement in eventbatch {

--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -1,3 +1,4 @@
+use crate::event_handler::DISGUISED_EVENT_OFFSETTER;
 use evdev::Key;
 use serde::{Deserialize, Deserializer};
 use std::error::Error;
@@ -48,46 +49,61 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
         "WIN_R" => Key::KEY_RIGHTMETA,
         "WIN_L" => Key::KEY_LEFTMETA,
 
-        //Entirely custom scancodes
+        //Custom aliases used in config files to represent scancodes for disguised relative events.
+        //Relative events are disguised into key events with those scancodes,
+        //and are then sent through modmap and keymap.
+        //
+        //These custom aliases are used in config files, like other aliases.
+        //The difference here is that since these scancodes don't map to any existing name,
+        //(on purpose, to avoid conflating disguised events and actual key events)
+        //we need to define them using scancodes instead of existing names.
+        //
+        //The DISGUISED_EVENT_OFFSETTER const is used here to make it easy to change the scancodes should it ever be necessary.
+        //Because configs use name and custom aliases, changing their assigned value doesn't change how to write configs;
+        //In other words, a config that works when DISGUISED_EVENT_OFFSETTER == 59974
+        //will work exactly the same way if DISGUISED_EVENT_OFFSETTER == 46221
+        //
+        //DISGUISED_EVENT_OFFSETTER is also used in tests.rs::verify_disguised_relative_events(),
+        //to prevent its modification to a number too low or too big.
         //
         //Cursor movement
-        "BTN_XRIGHTCURSOR" => evdev::Key(59974), //Cursor right
-        "BTN_XLEFTCURSOR" => evdev::Key(59975),  //Cursor left
-        "BTN_XDOWNCURSOR" => evdev::Key(59976),  //Cursor down
-        "BTN_XUPCURSOR" => evdev::Key(59977),    //Cursor up
+        "XRIGHTCURSOR" => Key(DISGUISED_EVENT_OFFSETTER), //Cursor right
+        "XLEFTCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 1), //Cursor left
+        "XDOWNCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 2), //Cursor down
+        "XUPCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 3), //Cursor up
         //Cursor... forward and backwards?
-        "BTN_XREL_Z_AXIS_1" => evdev::Key(59978),
-        "BTN_XREL_Z_AXIS_2" => evdev::Key(59979),
+        "XREL_Z_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 4),
+        "XREL_Z_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 5),
         //
         //Rotative cursor movement?
-        "BTN_XREL_RX_AXIS_1" => evdev::Key(59980), //horizontal
-        "BTN_XREL_RX_AXIS_2" => evdev::Key(59981),
-        "BTN_XREL_RY_AXIS_1" => evdev::Key(59982), //vertical
-        "BTN_XREL_RY_AXIS_2" => evdev::Key(59983),
-        "BTN_XREL_RZ_AXIS_1" => evdev::Key(59984), //Whatever the third dimensional axis is called
-        "BTN_XREL_RZ_AXIS_2" => evdev::Key(59985),
+        "XREL_RX_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 6), //horizontal
+        "XREL_RX_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 7),
+        "XREL_RY_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 8), //vertical
+        "XREL_RY_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 9),
+        "XREL_RZ_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 10), //Whatever the third dimensional axis is called
+        "XREL_RZ_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 11),
         //
-        "BTN_XRIGHTSCROLL" => evdev::Key(59986), //Rightscroll
-        "BTN_XLEFTSCROLL" => evdev::Key(59987),  //Leftscroll
+        "XRIGHTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 12), //Rightscroll
+        "XLEFTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 13),  //Leftscroll
         //
         //???
-        "BTN_XREL_DIAL_1" => evdev::Key(59988),
-        "BTN_XREL_DIAL_2" => evdev::Key(59989),
+        "XREL_DIAL_1" => Key(DISGUISED_EVENT_OFFSETTER + 14),
+        "XREL_DIAL_2" => Key(DISGUISED_EVENT_OFFSETTER + 15),
         //
-        "BTN_XUPSCROLL" => evdev::Key(59990),   //Upscroll
-        "BTN_XDOWNSCROLL" => evdev::Key(59991), //Downscroll
+        "XUPSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 16), //Upscroll
+        "XDOWNSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 17), //Downscroll
         //
         //Something?
-        "BTN_XREL_MISC_1" => evdev::Key(59992),
-        "BTN_XREL_MISC_2" => evdev::Key(59993),
-        "BTN_XREL_RESERVED_1" => evdev::Key(59994),
-        "BTN_XREL_RESERVED_2" => evdev::Key(59995),
+        "XREL_MISC_1" => Key(DISGUISED_EVENT_OFFSETTER + 18),
+        "XREL_MISC_2" => Key(DISGUISED_EVENT_OFFSETTER + 19),
+        "XREL_RESERVED_1" => Key(DISGUISED_EVENT_OFFSETTER + 20),
+        "XREL_RESERVED_2" => Key(DISGUISED_EVENT_OFFSETTER + 21),
         //
         //High resolution version of scroll events, sent just after their non-high resolution version.
-        "BTN_XHIRES_UPSCROLL" => evdev::Key(59996),
-        "BTN_XHIRES_DOWNSCROLL" => evdev::Key(59997),
-        "BTN_XHIRES_RIGHTSCROLL" => evdev::Key(59998),
-        "BTN_XHIRES_LEFTSCROLL" => evdev::Key(59999),
+        "XHIRES_UPSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 22),
+        "XHIRES_DOWNSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 23),
+        "XHIRES_RIGHTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 24),
+        "XHIRES_LEFTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 25),
         /* Original Relative events and their values for quick reference.
             REL_X = 0x00,
             REL_Y = 0x01,

--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -49,57 +49,57 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
         "WIN_R" => Key::KEY_RIGHTMETA,
         "WIN_L" => Key::KEY_LEFTMETA,
 
-        //Custom aliases used in config files to represent scancodes for disguised relative events.
-        //Relative events are disguised into key events with those scancodes,
-        //and are then sent through modmap and keymap.
+        // Custom aliases used in config files to represent scancodes for disguised relative events.
+        // Relative events are disguised into key events with those scancodes,
+        // and are then sent through modmap and keymap.
         //
-        //These custom aliases are used in config files, like other aliases.
-        //The difference here is that since these scancodes don't map to any existing name,
-        //(on purpose, to avoid conflating disguised events and actual key events)
-        //we need to define them using scancodes instead of existing names.
+        // These custom aliases are used in config files, like other aliases.
+        // The difference here is that since these scancodes don't map to any existing name,
+        // (on purpose, to avoid conflating disguised events and actual key events)
+        // we need to define them using scancodes instead of existing names.
         //
-        //The DISGUISED_EVENT_OFFSETTER const is used here to make it easy to change the scancodes should it ever be necessary.
-        //Because configs use name and custom aliases, changing their assigned value doesn't change how to write configs;
-        //In other words, a config that works when DISGUISED_EVENT_OFFSETTER == 59974
-        //will work exactly the same way if DISGUISED_EVENT_OFFSETTER == 46221
+        // The DISGUISED_EVENT_OFFSETTER const is used here to make it easy to change the scancodes should it ever be necessary.
+        // Because configs use name and custom aliases, changing their assigned value doesn't change how to write configs;
+        // In other words, a config that works when DISGUISED_EVENT_OFFSETTER == 59974
+        // will work exactly the same way if DISGUISED_EVENT_OFFSETTER == 46221
         //
-        //DISGUISED_EVENT_OFFSETTER is also used in tests.rs::verify_disguised_relative_events(),
-        //to prevent its modification to a number too low or too big.
+        // DISGUISED_EVENT_OFFSETTER is also used in tests.rs::verify_disguised_relative_events(),
+        // to prevent its modification to a number too low or too big.
         //
-        //Cursor movement
-        "XRIGHTCURSOR" => Key(DISGUISED_EVENT_OFFSETTER), //Cursor right
-        "XLEFTCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 1), //Cursor left
-        "XDOWNCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 2), //Cursor down
-        "XUPCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 3), //Cursor up
-        //Cursor... forward and backwards?
+        // Cursor movement
+        "XRIGHTCURSOR" => Key(DISGUISED_EVENT_OFFSETTER), // Cursor right
+        "XLEFTCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 1), // Cursor left
+        "XDOWNCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 2), // Cursor down
+        "XUPCURSOR" => Key(DISGUISED_EVENT_OFFSETTER + 3), // Cursor up
+        // Cursor... forward and backwards?
         "XREL_Z_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 4),
         "XREL_Z_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 5),
         //
-        //Rotative cursor movement?
-        "XREL_RX_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 6), //horizontal
+        // Rotative cursor movement?
+        "XREL_RX_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 6), // horizontal
         "XREL_RX_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 7),
-        "XREL_RY_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 8), //vertical
+        "XREL_RY_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 8), // vertical
         "XREL_RY_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 9),
-        "XREL_RZ_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 10), //Whatever the third dimensional axis is called
+        "XREL_RZ_AXIS_1" => Key(DISGUISED_EVENT_OFFSETTER + 10), // Whatever the third dimensional axis is called
         "XREL_RZ_AXIS_2" => Key(DISGUISED_EVENT_OFFSETTER + 11),
         //
-        "XRIGHTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 12), //Rightscroll
-        "XLEFTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 13),  //Leftscroll
+        "XRIGHTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 12), // Rightscroll
+        "XLEFTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 13),  // Leftscroll
         //
-        //???
+        // ???
         "XREL_DIAL_1" => Key(DISGUISED_EVENT_OFFSETTER + 14),
         "XREL_DIAL_2" => Key(DISGUISED_EVENT_OFFSETTER + 15),
         //
-        "XUPSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 16), //Upscroll
-        "XDOWNSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 17), //Downscroll
+        "XUPSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 16), // Upscroll
+        "XDOWNSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 17), // Downscroll
         //
-        //Something?
+        // Something?
         "XREL_MISC_1" => Key(DISGUISED_EVENT_OFFSETTER + 18),
         "XREL_MISC_2" => Key(DISGUISED_EVENT_OFFSETTER + 19),
         "XREL_RESERVED_1" => Key(DISGUISED_EVENT_OFFSETTER + 20),
         "XREL_RESERVED_2" => Key(DISGUISED_EVENT_OFFSETTER + 21),
         //
-        //High resolution version of scroll events, sent just after their non-high resolution version.
+        // High resolution version of scroll events, sent just after their non-high resolution version.
         "XHIRES_UPSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 22),
         "XHIRES_DOWNSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 23),
         "XHIRES_RIGHTSCROLL" => Key(DISGUISED_EVENT_OFFSETTER + 24),
@@ -119,7 +119,7 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
             REL_WHEEL_HI_RES = 0x0b,
             REL_HWHEEL_HI_RES = 0x0c,
         */
-        //End of custom scancodes
+        // End of custom scancodes
 
         // else
         _ => Key::KEY_RESERVED,

--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -47,6 +47,64 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
         "SUPER_L" => Key::KEY_LEFTMETA,
         "WIN_R" => Key::KEY_RIGHTMETA,
         "WIN_L" => Key::KEY_LEFTMETA,
+
+        //Entirely custom scancodes
+        //
+        //Cursor movement
+        "BTN_XRIGHTCURSOR" => evdev::Key(59974), //Cursor right
+        "BTN_XLEFTCURSOR" => evdev::Key(59975),  //Cursor left
+        "BTN_XDOWNCURSOR" => evdev::Key(59976),  //Cursor down
+        "BTN_XUPCURSOR" => evdev::Key(59977),    //Cursor up
+        //Cursor... forward and backwards?
+        "BTN_XREL_Z_AXIS_1" => evdev::Key(59978),
+        "BTN_XREL_Z_AXIS_2" => evdev::Key(59979),
+        //
+        //Rotative cursor movement?
+        "BTN_XREL_RX_AXIS_1" => evdev::Key(59980), //horizontal
+        "BTN_XREL_RX_AXIS_2" => evdev::Key(59981),
+        "BTN_XREL_RY_AXIS_1" => evdev::Key(59982), //vertical
+        "BTN_XREL_RY_AXIS_2" => evdev::Key(59983),
+        "BTN_XREL_RZ_AXIS_1" => evdev::Key(59984), //Whatever the third dimensional axis is called
+        "BTN_XREL_RZ_AXIS_2" => evdev::Key(59985),
+        //
+        "BTN_XRIGHTSCROLL" => evdev::Key(59986), //Rightscroll
+        "BTN_XLEFTSCROLL" => evdev::Key(59987),  //Leftscroll
+        //
+        //???
+        "BTN_XREL_DIAL_1" => evdev::Key(59988),
+        "BTN_XREL_DIAL_2" => evdev::Key(59989),
+        //
+        "BTN_XUPSCROLL" => evdev::Key(59990),   //Upscroll
+        "BTN_XDOWNSCROLL" => evdev::Key(59991), //Downscroll
+        //
+        //Something?
+        "BTN_XREL_MISC_1" => evdev::Key(59992),
+        "BTN_XREL_MISC_2" => evdev::Key(59993),
+        "BTN_XREL_RESERVED_1" => evdev::Key(59994),
+        "BTN_XREL_RESERVED_2" => evdev::Key(59995),
+        //
+        //High resolution version of scroll events, sent just after their non-high resolution version.
+        "BTN_XHIRES_UPSCROLL" => evdev::Key(59996),
+        "BTN_XHIRES_DOWNSCROLL" => evdev::Key(59997),
+        "BTN_XHIRES_RIGHTSCROLL" => evdev::Key(59998),
+        "BTN_XHIRES_LEFTSCROLL" => evdev::Key(59999),
+        /* Original Relative events and their values for quick reference.
+            REL_X = 0x00,
+            REL_Y = 0x01,
+            REL_Z = 0x02,
+            REL_RX = 0x03,
+            REL_RY = 0x04,
+            REL_RZ = 0x05,
+            REL_HWHEEL = 0x06,
+            REL_DIAL = 0x07,
+            REL_WHEEL = 0x08,
+            REL_MISC = 0x09,
+            REL_RESERVED = 0x0a,
+            REL_WHEEL_HI_RES = 0x0b,
+            REL_HWHEEL_HI_RES = 0x0c,
+        */
+        //End of custom scancodes
+
         // else
         _ => Key::KEY_RESERVED,
     };

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,6 +7,8 @@ pub enum Event {
     KeyEvent(KeyEvent),
     // InputEvent (EventType::Relative) sent from evdev
     RelativeEvent(RelativeEvent),
+    // Any other InputEvent type sent from evdev
+    OtherEvents(InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
@@ -31,13 +33,13 @@ pub enum KeyValue {
 }
 impl Event {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(event: InputEvent) -> Option<Event> {
+    pub fn new(event: InputEvent) -> Event {
         let event = match event.event_type() {
             EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value())),
             EventType::RELATIVE => Event::RelativeEvent(RelativeEvent::new_with(event.code(), event.value())),
-            _ => return None,
+            _ => Event::OtherEvents(event),
         };
-        Some(event)
+        event
     }
 }
 
@@ -63,7 +65,7 @@ impl KeyEvent {
     }
 }
 
-//constructor for relative events.
+// constructor for relative events.
 impl RelativeEvent {
     pub fn new_with(code: u16, value: i32) -> RelativeEvent {
         RelativeEvent { code, value }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,6 +5,8 @@ use evdev::{EventType, InputEvent, Key};
 pub enum Event {
     // InputEvent (EventType::KEY) sent from evdev
     KeyEvent(KeyEvent),
+    // InputEvent (EventType::Relative) sent from evdev
+    RelativeEvent(RelativeEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
@@ -16,17 +18,23 @@ pub struct KeyEvent {
 }
 
 #[derive(Debug)]
+pub struct RelativeEvent {
+    pub code: u16,
+    pub value: i32,
+}
+
+#[derive(Debug)]
 pub enum KeyValue {
     Press,
     Release,
     Repeat,
 }
-
 impl Event {
     // Convert evdev's raw InputEvent to xremap's internal Event
     pub fn new(event: InputEvent) -> Option<Event> {
         let event = match event.event_type() {
             EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => Event::RelativeEvent(RelativeEvent::new_with(event.code(), event.value())),
             _ => return None,
         };
         Some(event)
@@ -52,6 +60,13 @@ impl KeyEvent {
 
     pub fn value(&self) -> i32 {
         self.value.value()
+    }
+}
+
+//constructor for relative events.
+impl RelativeEvent {
+    pub fn new_with(code: u16, value: i32) -> RelativeEvent {
+        RelativeEvent { code, value }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ struct Opts {
         verbatim_doc_comment,
         hide_possible_values = true,
         // Separating the help like this is necessary due to
-        // https:// github.com/clap-rs/clap/issues/3312
+        // https://github.com/clap-rs/clap/issues/3312
         help = "Targets to watch [possible values: device, config]"
     )]
     watch: Vec<WatchTargets>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+use evdev::EventType;
+use evdev::InputEvent;
 use evdev::Key;
 use indoc::indoc;
 use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
@@ -7,7 +9,7 @@ use crate::client::{Client, WMClient};
 use crate::{
     action::Action,
     config::{keymap::build_keymap_table, Config},
-    event::{Event, KeyEvent, KeyValue},
+    event::{Event, KeyEvent, KeyValue, RelativeEvent},
     event_handler::EventHandler,
 };
 
@@ -46,6 +48,167 @@ fn test_basic_modmap() {
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
         ],
     )
+}
+
+/* Table to see which scancodes/custom key events correspond to which relative events
+    Original RELATIVE event | scancode | Custom keyname if                              | Info
+                            |          | positive value (+)     | negative value (-)    |
+    REL_X                   |    0     | BTN_XRIGHTCURSOR       | BTN_XLEFTCURSOR       | Cursor right and left
+    REL_Y                   |    1     | BTN_XDOWNCURSOR        | BTN_XUPCURSOR         | Cursor down and up
+    REL_Z                   |    2     | BTN_XREL_Z_AXIS_1      | BTN_XREL_Z_AXIS_2     | Cursor... forward and backwards?
+    REL_RX                  |    3     | BTN_XREL_RX_AXIS_1     | BTN_XREL_RX_AXIS_2    | Horizontally rotative cursor movement?
+    REL_RY                  |    4     | BTN_XREL_RY_AXIS_1     | BTN_XREL_RY_AXIS_2    | Vertical rotative cursor movement?
+    REL_RZ                  |    5     | BTN_XREL_RZ_AXIS_1     | BTN_XREL_RZ_AXIS_2    | "Whatever the third dimensional axis is called" rotative cursor movement?
+    REL_HWHEEL              |    6     | BTN_XRIGHTSCROLL       | BTN_XLEFTSCROLL       | Rightscroll and leftscroll
+    REL_DIAL                |    7     | BTN_XREL_DIAL_1        | BTN_XREL_DIAL_2       | ???
+    REL_WHEEL               |    8     | BTN_XUPSCROLL          | BTN_XDOWNSCROLL       | Upscroll and downscroll
+    REL_MISC                |    9     | BTN_XREL_MISC_1        | BTN_XREL_MISC_2       | Something?
+    REL_RESERVED            |    10    | BTN_XREL_RESERVED_1    | BTN_XREL_RESERVED_2   | Something?
+    REL_WHEEL_HI_RES        |    11    | BTN_XHIRES_UPSCROLL    | BTN_XHIRES_DOWNSCROLL | High resolution downscroll and upscroll, sent just after their non-high resolution version
+    REL_HWHEEL_HI_RES       |    12    | BTN_XHIRES_RIGHTSCROLL | BTN_XHIRES_LEFTSCROLL | High resolution rightcroll and leftscroll, sent just after their non-high resolution version
+*/
+
+const _POSITIVE: i32 = 1;
+const _NEGATIVE: i32 = -1;
+
+const _REL_X: u16 = 0;
+const _REL_Y: u16 = 1;
+const _REL_Z: u16 = 2;
+const _REL_RX: u16 = 3;
+const _REL_RY: u16 = 4;
+const _REL_RZ: u16 = 5;
+const _REL_HWHEEL: u16 = 6;
+const _REL_DIAL: u16 = 7;
+const _REL_WHEEL: u16 = 8;
+const _REL_MISC: u16 = 9;
+const _REL_RESERVED: u16 = 10;
+const _REL_WHEEL_HI_RES: u16 = 11;
+const _REL_HWHEEL_HI_RES: u16 = 12;
+
+#[test]
+fn test_relative_events() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              BTN_XRIGHTCURSOR: b
+        "},
+        vec![Event::RelativeEvent(RelativeEvent::new_with(_REL_X, _POSITIVE))],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+#[ignore]
+// The OS interprets a REL_X¹ event combined with a REL_Y event² differently if they are separated by synchronization event.
+// This test and test_cursor_behavior_2 are meant to be run to demonstrate that fact.
+
+//¹Mouse movement along the X (horizontal) axis.
+//²Mouse movement along the Y (vertical) axis.
+
+// The only difference between test_cursor_behavior_1 and test_cursor_behavior_2 is that
+// test_cursor_behavior_1 adds a synchronization event between REL_X and REL_Y events that would not normally be there.
+// In other words, test_cursor_behavior_2 represents what would occur without Xremap intervention.
+
+// Here's how to proceed :
+// 1 - Move your mouse cursor to the bottom left of your screen.
+// 2 - either run this test with sudo privileges or while your environnment is properly set up (https://github.com/k0kubun/xremap#running-xremap-without-sudo),
+//     so that your keyboard and/or mouse may be captured.
+
+// 3 - Press any button (don't move the mouse).
+// 4 - Note where the cursor ended up.
+
+// 5 - Repeat steps 1 through 4 for test_cursor_behavior_2.
+// 6 - Notice that the mouse cursor often ends up in a different position than when running test_cursor_behavior_1.
+
+//
+// Notes :
+// - Because emitting an event automatcially adds a synchronization event afterwards (see https://github.com/emberian/evdev/blob/1d020f11b283b0648427a2844b6b980f1a268221/src/uinput.rs#L167),
+//   Mouse movement events should be batched together when emitted,
+//   to avoid separating them with a synchronization event.
+//
+// - Because a mouse will only ever send a maximum of one REL_X and one REL_Y (and maybe one REL_Z for 3D mice?) at once,
+//   the only point where a synchronization event can be added where it shouldn't by Xremap is between those events,
+//   meaning this bug is exclusive to diagonal mouse movement.
+//
+// - The call to std::thread::sleep for five milliseconds is meant to emulate
+//   the interval between events from a mouse with a frequency of ~200 Hz.
+//   A lower time interval between events (which would correspond to a mouse with a higher frequency)
+//   would cause the difference between test_cursor_behavior_1 and test_cursor_behavior_2 to become less noticeable.
+//   Conversely, a higher time interval would make the difference more noticeable.
+//
+fn test_cursor_behavior_1() {
+    use crate::device::InputDevice;
+    use crate::device::{get_input_devices, output_device};
+    //Setup to be able to send events
+    let mut input_devices = match get_input_devices(&[String::from("/dev/input/event25")], &[], true, false) {
+        Ok(input_devices) => input_devices,
+        Err(e) => panic!("Failed to prepare input devices: {}", e),
+    };
+    let mut output_device = match output_device(input_devices.values().next().map(InputDevice::bus_type)) {
+        Ok(output_device) => output_device,
+        Err(e) => panic!("Failed to prepare an output device: {}", e),
+    };
+    for input_device in input_devices.values_mut() {
+        let _unused = input_device.fetch_events().unwrap();
+    }
+
+    //Looping 400 times amplifies the difference between test_cursor_behavior_1 and test_cursor_behavior_2 to visible levels.
+    for _ in 0..400 {
+        output_device
+            .emit(&[
+                InputEvent::new_now(EventType::RELATIVE, _REL_X, _POSITIVE),
+                //
+                //This line is the only difference between test_cursor_behavior_1 and test_cursor_behavior_2.
+                InputEvent::new(EventType::SYNCHRONIZATION, 0, 0),
+                //
+                InputEvent::new_now(EventType::RELATIVE, _REL_Y, _NEGATIVE),
+            ])
+            .unwrap();
+
+        //Creating a time interval between mouse movement events to simulate a mouse with a frequency of ~200 Hz.
+        //The smaller the time interval, the smaller the difference between test_cursor_behavior_1 and test_cursor_behavior_2.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+#[test]
+#[ignore]
+// The OS interprets a REL_X¹ event combined with a REL_Y event² differently if they are separated by synchronization event.
+// This test and test_cursor_behavior_1 are meant to be run to demonstrate that fact.
+// Please refer to the comment above test_cursor_behavior_1 for information on how to run these tests.
+fn test_cursor_behavior_2() {
+    use crate::device::InputDevice;
+    use crate::device::{get_input_devices, output_device};
+    //Setup to be able to send events
+    let mut input_devices = match get_input_devices(&[String::from("/dev/input/event25")], &[], true, false) {
+        Ok(input_devices) => input_devices,
+        Err(e) => panic!("Failed to prepare input devices: {}", e),
+    };
+    let mut output_device = match output_device(input_devices.values().next().map(InputDevice::bus_type)) {
+        Ok(output_device) => output_device,
+        Err(e) => panic!("Failed to prepare an output device: {}", e),
+    };
+    for input_device in input_devices.values_mut() {
+        let _unused = input_device.fetch_events().unwrap();
+    }
+
+    //Looping 400 times amplifies the difference between test_cursor_behavior_1 and test_cursor_behavior_2 to visible levels.
+    for _ in 0..400 {
+        output_device
+            .emit(&[
+                InputEvent::new_now(EventType::RELATIVE, _REL_X, _POSITIVE),
+                InputEvent::new_now(EventType::RELATIVE, _REL_Y, _NEGATIVE),
+            ])
+            .unwrap();
+
+        //Creating a time interval between mouse movement events to simulate a mouse with a frequency of ~200 Hz.
+        //The smaller the time interval, the smaller the difference between test_cursor_behavior_1 and test_cursor_behavior_2.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
 }
 
 #[test]


### PR DESCRIPTION
The way i did this takes relative events and sends two fake key inputs to modmap.
(i added the fake key inputs to evdev's enum of key scancodes : https://github.com/GitPerseus/evdev/pull/1 ).

The first key input has a value of 1 and the second a value of 0, to simulate a instant press/unpress.

Note: My code isn't able to send relative event, only receive them.


It should also be possible to support more event types in about the same way.