### PR TITLE
Document feature that allows app-specific key overrides of a generic key map

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,26 @@ swaymsg -t get_tree
 
 Locate `app_id` in the output.
 
+#### application-specific key overrides
+
+Sometimes you want to define a generic key map that is available in all applications, but give specific keys in that map their own definition in specific applications. You can do this by putting the generic map at the bottom of the config, after any specific overrides, as follows.
+
+```yml
+# Emacs-style word-forward and word-back
+keymap:
+  - name: override to make libreoffice-writer go to end of word but before final space like emacs
+    application:
+      only: libreoffice-writter
+    remap:
+      Alt-f: [right, C-right, left]
+  - name: generic for all apps
+    remap:
+      Alt-f: C-right
+      Alt-b: C-left
+```
+
+Note how Alt-f and Alt-b work in all apps, but the definition of Alt-f is slightly different in LibreOffice Writer. When that app is active, the first definition overrides the second definition; but for any other app, only the second definition is found. This is because xremap uses the first matching definition that it finds.
+
 ### virtual\_modifiers
 
 You can declare keys that should act like a modifier.
@@ -300,6 +320,8 @@ keymap:
 Some applications have trouble understanding synthesized key events, especially on
 Wayland. `keypress_delay_ms` can be used to workaround the issue.
 See [#179](https://github.com/k0kubun/xremap/issues/179) for the detail.
+
+key overrides
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -321,8 +321,6 @@ Some applications have trouble understanding synthesized key events, especially 
 Wayland. `keypress_delay_ms` can be used to workaround the issue.
 See [#179](https://github.com/k0kubun/xremap/issues/179) for the detail.
 
-key overrides
-
 ## License
 
 `xremap` is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/example/config.yml
+++ b/example/config.yml
@@ -25,49 +25,6 @@ modmap:
       KatakanaHiragana: Alt_L
 
 keymap:
-  - name: Global
-    remap:
-      # Underscore without Shift
-      RO: Shift-RO
-
-      # SKK hack for Chrome
-      C-j: C-m
-
-  - name: Default (Nocturn, etc.)
-    application:
-      not: [Google-chrome, Slack, Gnome-terminal, jetbrains-idea]
-    remap:
-      # Emacs basic
-      C-b: left
-      C-f: right
-      C-p: up
-      C-n: down
-
-      # Emacs word
-      Super-b: C-left
-      Super-f: C-right
-
-      # Emacs lines
-      C-a: home # TODO: Alt-C-a
-      C-e: end # TODO: Alt-C-e
-      C-k: [Shift-end, backspace] # TODO: Alt-C-k
-
-      # Alt -> Ctrl
-      Super-a: C-a
-      Super-z: C-z
-      Super-x: C-x
-      Super-c: C-c
-      Super-v: C-v
-      Super-w: C-w
-      Super-t: C-t
-      Super-l: C-l
-
-      # actually these are vim insert mode bindings, but compatible with shell
-      C-w: [C-Shift-left, delete]
-
-      C-d: delete
-      Super-d: C-delete
-
   - name: IDEA (modified from Default)
     application:
       only: jetbrains-idea
@@ -112,57 +69,12 @@ keymap:
       # workaround
       C-c: Esc
 
-  - name: Chrome, Slack (modified from Default)
-    application:
-      only: [Google-chrome, Slack]
-    remap:
-      # Emacs basic
-      C-b: left
-      C-f: right
-      C-p: up
-      C-n: down
-
-      # Emacs word
-      Super-b: C-left
-      Super-f: C-right
-
-      # Emacs lines
-      C-a: home
-      C-e: end
-      C-k: [Shift-end, backspace]
-
-      # Alt -> Ctrl
-      Super-a: C-a
-      Super-z: C-z
-      Super-x: C-x
-      Super-c: C-c
-      Super-v: C-v
-      Super-w: C-w
-      Super-t: C-t
-      Super-l: C-l
-
-      # actually these are vim insert mode bindings, but compatible with shell
-      C-w: [C-Shift-left, delete]
-
-      # Tabs
-      Super-o: C-Shift-tab
-      Super-p: C-tab
-
-      C-d: delete
-      Super-d: C-delete
-
-  - name: Tab changes + Alt-Enter simulation
-    application:
-      not: [Gnome-terminal, Nocturn]
-    remap:
-      Super-o: C-Shift-tab
-      Super-p: C-tab
-      Super-Enter: M-Enter
-
   - name: Google Search
     application:
       only: Google-chrome
     remap:
+      Super-o: C-Shift-tab
+      Super-p: C-tab
       Super-s: C-f
 
   - name: Terminal
@@ -198,6 +110,8 @@ keymap:
     application:
       only: Slack
     remap:
+      Super-o: C-Shift-tab
+      Super-p: C-tab
       Super-n: C-k
       Super-k: M-up
       Super-j: M-down
@@ -213,3 +127,49 @@ keymap:
       Super-7: C-7
       Super-8: C-8
       Super-9: C-9
+
+  - name: Default -- some of these are overridden by the above definitions
+    application:
+      not: [Google-chrome, Slack, Gnome-terminal, jetbrains-idea]
+    remap:
+      # Emacs basic
+      C-b: left
+      C-f: right
+      C-p: up
+      C-n: down
+
+      # Emacs word
+      Super-b: C-left
+      Super-f: C-right
+
+      # Emacs lines
+      C-a: home # TODO: Alt-C-a
+      C-e: end # TODO: Alt-C-e
+      C-k: [Shift-end, backspace] # TODO: Alt-C-k
+
+      # Alt -> Ctrl
+      Super-a: C-a
+      Super-z: C-z
+      Super-x: C-x
+      Super-c: C-c
+      Super-v: C-v
+      Super-w: C-w
+      Super-t: C-t
+      Super-l: C-l
+
+      # Tab changes + Alt-Enter simulation
+      Super-o: C-Shift-tab
+      Super-p: C-tab
+      Super-Enter: M-Enter
+
+      # actually these are vim insert mode bindings, but compatible with shell
+      C-w: [C-Shift-left, delete]
+
+      C-d: delete
+      Super-d: C-delete
+
+      # Underscore without Shift
+      RO: Shift-RO
+
+      # SKK hack for Chrome
+      C-j: C-m


### PR DESCRIPTION
This documents an accidental feature that allows keys from a generic key map to be overridden for specific applications. Addresses issue #163.