### PR TITLE
Interleave pressing/releasing of modifier keys.

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -343,8 +343,8 @@ impl EventHandler {
         missing_modifiers.retain(|key| MODIFIER_KEYS.contains(&key));
 
         // Emulate the modifiers of KeyPress
-        self.send_keys(&extra_modifiers, RELEASE);
         self.send_keys(&missing_modifiers, PRESS);
+        self.send_keys(&extra_modifiers, RELEASE);
 
         // Press the main key
         self.send_key(&key_press.key, PRESS);
@@ -353,8 +353,8 @@ impl EventHandler {
         self.send_action(Action::Delay(self.keypress_delay));
 
         // Resurrect the original modifiers
-        self.send_keys(&missing_modifiers, RELEASE);
         self.send_keys(&extra_modifiers, PRESS);
+        self.send_keys(&missing_modifiers, RELEASE);
     }
 
     fn with_mark(&self, key_press: &KeyPress) -> KeyPress {


### PR DESCRIPTION
Pressing new modifier keys before releasing the old ones to avoid triggering actions in applications that recognize the old keys.

For example, if we bind <kbd>alt+f</kbd> to <kbd>ctrl+right</kbd>, before this change, the following key sequence is generated with <kbd>alt+f</kbd>:

```
(user)       send Alt_L      PRESS
(xremap)     send Alt_L      RELEASE
(xremap)     send Control_L  PRESS
(xremap)     send Right      PRESS
(xremap)     send Right      RELEASE
(xremap)     send Control_L  RELEASE
(xremap)     send Alt_L      PRESS
(user)       send Alt_L      RELEASE
```

The press + release of the <kbd>alt</kbd> key (both at the start and end of the sequence) is causing apps like Firefox to show/focus the menu bar.

After this change, the following key sequence is generated with <kbd>alt+f</kbd>:

```
(user)       send Alt_L      PRESS
(xremap)     send Control_L  PRESS
(xremap)     send Alt_L      RELEASE
(xremap)     send Right      PRESS
(xremap)     send Right      RELEASE
(xremap)     send Alt_L      PRESS
(xremap)     send Control_L  RELEASE
(user)       send Alt_L      RELEASE
```

So the difference here is that we press the <kbd>ctrl</kbd> key before releasing alt, so will not trigger apps like Firefox to show hide the menu when <kbd>alt+f</kbd> is used, and a single press and release of the <kbd>alt</kbd> key will still show the menu as their normal behavior.

As far as I can observe, this is also the behavior of AutoHotKey on Windows.