### PR TITLE
Introduce keymap level `exact_match` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ is supported only in `modmap` since `keymap` handles modifier keys differently.
 ```yml
 modmap:
   - name: Name # Optional
+    exact_match: false # Optional, defaults to false
     remap: # Required
       # Replace a key with another
       KEY_XXX: KEY_YYY # Required
@@ -234,6 +235,12 @@ You may also suffix them with `_L` or `_R` (case-insensitive) so that
 remapping is triggered only on a left or right modifier, e.g. `Ctrl_L-a`.
 
 If you use `virtual_modifiers` explained below, you can use it in the `MOD1-` part too.
+
+`exact_match` defines whether to use exact match when matching key presses. For
+example, given a mapping of `C-n: down` and `exact_match: false` (default), and
+you pressed <kbd>C-Shift-n</kbd>, it will automatically be remapped to
+<kbd>Shift-down</kbd>, without you having to define a mapping for
+<kbd>C-Shift-n</kbd>, which you would have to do if you use `exact_match: true`.
 
 ### application
 

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -19,6 +19,8 @@ pub struct Keymap {
     pub application: Option<Application>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub mode: Option<Vec<String>>,
+    #[serde(default)]
+    pub exact_match: bool,
 }
 
 fn deserialize_remap<'de, D>(deserializer: D) -> Result<HashMap<KeyPress, Vec<KeymapAction>>, D::Error>
@@ -39,6 +41,7 @@ pub struct KeymapEntry {
     pub modifiers: Vec<Modifier>,
     pub application: Option<Application>,
     pub mode: Option<Vec<String>>,
+    pub exact_match: bool,
 }
 
 // Convert an array of keymaps to a single hashmap whose key is a triggering key.
@@ -60,6 +63,7 @@ pub fn build_keymap_table(keymaps: &Vec<Keymap>) -> HashMap<Key, Vec<KeymapEntry
                 modifiers: key_press.modifiers.clone(),
                 application: keymap.application.clone(),
                 mode: keymap.mode.clone(),
+                exact_match: keymap.exact_match,
             });
             table.insert(key_press.key, entries);
         }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -259,12 +259,17 @@ impl EventHandler {
         if let Some(override_remap) = &self.override_remap {
             if let Some(entries) = override_remap.clone().get(key) {
                 self.remove_override()?;
-                for entry in entries {
-                    let (extra_modifiers, missing_modifiers) = self.diff_modifiers(&entry.modifiers);
-                    if (self.override_remap_exact_match && extra_modifiers.len() > 0) || missing_modifiers.len() > 0 {
+                for exact_match in [true, false] {
+                    if self.override_remap_exact_match && !exact_match {
                         continue;
                     }
-                    return Ok(Some(with_extra_modifiers(&entry.actions, &extra_modifiers)));
+                    for entry in entries {
+                        let (extra_modifiers, missing_modifiers) = self.diff_modifiers(&entry.modifiers);
+                        if (exact_match && extra_modifiers.len() > 0) || missing_modifiers.len() > 0 {
+                            continue;
+                        }
+                        return Ok(Some(with_extra_modifiers(&entry.actions, &extra_modifiers)));
+                    }
                 }
             }
             // An override remap is set but not used. Flush the pending key.

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -31,6 +31,8 @@ pub struct EventHandler {
     multi_purpose_keys: HashMap<Key, MultiPurposeKeyState>,
     // Current nested remaps
     override_remap: Option<HashMap<Key, Vec<OverrideEntry>>>,
+    // Whether to use exact match for override remaps
+    override_remap_exact_match: bool,
     // Key triggered on a timeout of nested remaps
     override_timeout_key: Option<Key>,
     // Trigger a timeout of nested remaps through select(2)
@@ -57,6 +59,7 @@ impl EventHandler {
             application_cache: None,
             multi_purpose_keys: HashMap::new(),
             override_remap: None,
+            override_remap_exact_match: false,
             override_timeout_key: None,
             override_timer: timer,
             mode: mode.to_string(),
@@ -256,14 +259,12 @@ impl EventHandler {
         if let Some(override_remap) = &self.override_remap {
             if let Some(entries) = override_remap.clone().get(key) {
                 self.remove_override()?;
-                for exact_match in [true, false] {
-                    for entry in entries {
-                        let (extra_modifiers, missing_modifiers) = self.diff_modifiers(&entry.modifiers);
-                        if (exact_match && extra_modifiers.len() > 0) || missing_modifiers.len() > 0 {
-                            continue;
-                        }
-                        return Ok(Some(with_extra_modifiers(&entry.actions, &extra_modifiers)));
+                for entry in entries {
+                    let (extra_modifiers, missing_modifiers) = self.diff_modifiers(&entry.modifiers);
+                    if (self.override_remap_exact_match && extra_modifiers.len() > 0) || missing_modifiers.len() > 0 {
+                        continue;
                     }
+                    return Ok(Some(with_extra_modifiers(&entry.actions, &extra_modifiers)));
                 }
             }
             // An override remap is set but not used. Flush the pending key.
@@ -272,6 +273,9 @@ impl EventHandler {
         if let Some(entries) = config.keymap_table.get(key) {
             for exact_match in [true, false] {
                 for entry in entries {
+                    if entry.exact_match && !exact_match {
+                        continue;
+                    }
                     let (extra_modifiers, missing_modifiers) = self.diff_modifiers(&entry.modifiers);
                     if (exact_match && extra_modifiers.len() > 0) || missing_modifiers.len() > 0 {
                         continue;
@@ -286,6 +290,7 @@ impl EventHandler {
                             continue;
                         }
                     }
+                    self.override_remap_exact_match = entry.exact_match;
                     return Ok(Some(with_extra_modifiers(&entry.actions, &extra_modifiers)));
                 }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -58,6 +58,145 @@ fn test_interleave_modifiers() {
     )
 }
 
+#[test]
+fn test_exact_match_true() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - exact_match: true
+            remap:
+              M-f: C-right
+        "},
+        vec![
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+        ],
+    )
+}
+
+#[test]
+fn test_exact_match_false() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - exact_match: false
+            remap:
+              M-f: C-right
+        "},
+        vec![
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_RIGHT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_RIGHT, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_exact_match_default() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              M-f: C-right
+        "},
+        vec![
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_RIGHT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_RIGHT, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_exact_match_true_nested() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - exact_match: true
+            remap:
+              C-x:
+                remap:
+                  h: C-a
+        "},
+        vec![
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+        ],
+    )
+}
+
+#[test]
+fn test_exact_match_false_nested() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - exact_match: false
+            remap:
+              C-x:
+                remap:
+                  h: C-a
+        "},
+        vec![
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    )
+}
+
 fn assert_actions(config_yaml: &str, events: Vec<Event>, actions: Vec<Action>) {
     let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap();
     let mut config: Config = serde_yaml::from_str(config_yaml).unwrap();


### PR DESCRIPTION
Related to https://github.com/k0kubun/xremap/issues/197 and https://github.com/k0kubun/xremap/issues/102

Example:

```yaml
  keymap:
    - exact_match: true
      remap:
        M-f: C-right
```

Given the above, and <kbd>M-Shift-f</kbd> is pressed:

- If `exact_match` is false or unset, the existing behaviour will be used,
  which will translate <kbd>M-Shift-f</kbd> to <kbd>C-Shift-right</kbd>.

- If `exact_match` is true, <kbd>M-Shift-f</kbd> will be sent as is, i.e. not matched.
