### PR TITLE
Clarify docs to say xremap should runx as daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,14 @@ If you are using NixOS, xremap can be installed and configured through a [flake]
 
 Write [a config file](#Configuration) directly, or generate it with
 [xremap-ruby](https://github.com/xremap/xremap-ruby) or [xremap-python](https://github.com/xremap/xremap-python).
-Then run:
+
+Then start the `xremap` daemon by runing:
 
 ```
 sudo xremap config.yml
 ```
+
+(You will need to leave it running for your mappings to take effect.)
 
 <details>
 <summary>If you want to run xremap without sudo, click here.</summary>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you are using NixOS, xremap can be installed and configured through a [flake]
 Write [a config file](#Configuration) directly, or generate it with
 [xremap-ruby](https://github.com/xremap/xremap-ruby) or [xremap-python](https://github.com/xremap/xremap-python).
 
-Then start the `xremap` daemon by runing:
+Then start the `xremap` daemon by running:
 
 ```
 sudo xremap config.yml


### PR DESCRIPTION
Fixes #372

This PR makes a minor documentation improvement to alleviate confusion when first running `xremap`.

I naively assumed that `xremap` needed to run briefly in order to mutate some sort of persistent global OS state and then exit, _after_ which point my mappings would work. Now I see that I need to _leave `xremap` running_. I'm hoping that this documentation improvement will help other avoid the same confusion I had.