### PR TITLE
Support device-specific remapping in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * Remap a key sequence as well. You could do something like Emacs's `C-x C-c`.
 * Remap a key to two different keys depending on whether it's pressed alone or held.
 * Application-specific remapping. Even if it's not supported by your application, xremap can.
+* Device-specific remapping.
 * Automatically remap newly connected devices by starting xremap with `--watch`.
 * Support [Emacs-like key remapping](example/emacs.yml), including the mark mode.
 * Trigger commands on key press/release events.
@@ -349,6 +350,29 @@ keymap:
 ```
 
 Note how Alt-f and Alt-b work in all apps, but the definition of Alt-f is slightly different in LibreOffice Writer. When that app is active, the first definition overrides the second definition; but for any other app, only the second definition is found. This is because xremap uses the first matching definition that it finds.
+
+### device
+
+Much like [`application`](#application), you may specify `{keymap,modmap}.device.{not,only}` in your configuration for device-specific remapping. Consistent with the global `--device` flag, device-matching strings may be any of:
+- the full path of the device
+- the filename of the device
+- the device name
+- a substring of the device name
+
+```yml
+device:
+  not: '/dev/input/event0'
+  # or
+  not: ['event0', ...]
+  # or
+  only: 'Some Cool Device Name'
+  # or
+  only: ['Cool Device', ...]
+  # etc...
+```
+
+Unlike for `application`, regexs are not supported for `device`.
+
 
 ### virtual\_modifiers
 

--- a/src/config/device.rs
+++ b/src/config/device.rs
@@ -1,0 +1,12 @@
+use serde::Deserialize;
+use crate::config::application::deserialize_string_or_vec;
+
+// TODO: Use trait to allow only either `only` or `not`
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Device {
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub only: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
+    pub not: Option<Vec<String>>,
+}

--- a/src/config/device.rs
+++ b/src/config/device.rs
@@ -1,5 +1,5 @@
-use serde::Deserialize;
 use crate::config::application::deserialize_string_or_vec;
+use serde::Deserialize;
 
 // TODO: Use trait to allow only either `only` or `not`
 #[derive(Clone, Debug, Deserialize)]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -42,6 +42,7 @@ pub struct KeymapEntry {
     pub actions: Vec<KeymapAction>,
     pub modifiers: Vec<Modifier>,
     pub application: Option<Application>,
+    pub device: Option<Device>,
     pub mode: Option<Vec<String>>,
     pub exact_match: bool,
 }
@@ -64,6 +65,7 @@ pub fn build_keymap_table(keymaps: &Vec<Keymap>) -> HashMap<Key, Vec<KeymapEntry
                 actions: actions.to_vec(),
                 modifiers: key_press.modifiers.clone(),
                 application: keymap.application.clone(),
+                device: keymap.device.clone(),
                 mode: keymap.mode.clone(),
                 exact_match: keymap.exact_match,
             });

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -6,6 +6,7 @@ use evdev::Key;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 
+use super::device::Device;
 use super::key_press::Modifier;
 
 // Config interface
@@ -17,6 +18,7 @@ pub struct Keymap {
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<KeyPress, Vec<KeymapAction>>,
     pub application: Option<Application>,
+    pub device: Option<Device>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub mode: Option<Vec<String>>,
     #[serde(default)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod application;
+mod device;
 mod key;
 pub mod key_press;
 pub mod keymap;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,5 @@
 pub mod application;
-mod device;
+pub mod device;
 mod key;
 pub mod key_press;
 pub mod keymap;

--- a/src/config/modmap.rs
+++ b/src/config/modmap.rs
@@ -5,6 +5,8 @@ use evdev::Key;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 
+use super::device::Device;
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Modmap {
@@ -13,6 +15,7 @@ pub struct Modmap {
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<Key, ModmapAction>,
     pub application: Option<Application>,
+    pub device: Option<Device>,
 }
 
 fn deserialize_remap<'de, D>(deserializer: D) -> Result<HashMap<Key, ModmapAction>, D::Error>

--- a/src/device.rs
+++ b/src/device.rs
@@ -11,7 +11,7 @@ use std::error::Error;
 use std::fs::read_dir;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::prelude::AsRawFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{io, process};
 
 static MOUSE_BTNS: [&str; 20] = [
@@ -203,25 +203,19 @@ impl InputDevice {
 
     pub fn to_info(&self) -> InputDeviceInfo {
         InputDeviceInfo {
-            name: self.device_name().to_string(),
-            path: self.path.clone(),
+            name: self.device_name(),
+            path: &self.path,
         }
     }
 }
 
 #[derive(Debug)]
-pub struct InputDeviceInfo {
-    name: String,
-    path: PathBuf,
+pub struct InputDeviceInfo<'a> {
+    pub name: &'a str,
+    pub path: &'a Path,
 }
 
-impl InputDeviceInfo {
-    pub fn new(name: &str, path: &str) -> Self {
-        Self {
-            name: String::from(name),
-            path: PathBuf::from(path),
-        }
-    }
+impl<'a> InputDeviceInfo<'a> {
     pub fn matches(&self, filter: &String) -> bool {
         let filter = filter.as_str();
         // Check exact matches for explicit selection

--- a/src/device.rs
+++ b/src/device.rs
@@ -133,7 +133,7 @@ pub fn get_input_devices(
     Ok(devices.into_iter().map(From::from).collect())
 }
 
-#[derive_where(PartialEq, PartialOrd, Ord, Debug)]
+#[derive_where(PartialEq, PartialOrd, Ord)]
 pub struct InputDevice {
     path: PathBuf,
     #[derive_where(skip)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -133,6 +133,31 @@ pub fn get_input_devices(
     Ok(devices.into_iter().map(From::from).collect())
 }
 
+#[derive(Debug)]
+pub struct InputDeviceInfo<'a> {
+    pub name: &'a str,
+    pub path: &'a Path,
+}
+
+impl<'a> InputDeviceInfo<'a> {
+    pub fn matches(&self, filter: &String) -> bool {
+        let filter = filter.as_str();
+        // Check exact matches for explicit selection
+        if self.path.as_os_str() == filter || self.name == filter {
+            return true;
+        }
+        // eventXX shorthand for /dev/input/eventXX
+        if filter.starts_with("event") && self.path.file_name().expect("every device path has a file name") == filter {
+            return true;
+        }
+        // Allow partial matches for device names
+        if self.name.contains(filter) {
+            return true;
+        }
+        return false;
+    }
+}
+
 #[derive_where(PartialEq, PartialOrd, Ord)]
 pub struct InputDevice {
     path: PathBuf,
@@ -206,31 +231,6 @@ impl InputDevice {
             name: self.device_name(),
             path: &self.path,
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct InputDeviceInfo<'a> {
-    pub name: &'a str,
-    pub path: &'a Path,
-}
-
-impl<'a> InputDeviceInfo<'a> {
-    pub fn matches(&self, filter: &String) -> bool {
-        let filter = filter.as_str();
-        // Check exact matches for explicit selection
-        if self.path.as_os_str() == filter || self.name == filter {
-            return true;
-        }
-        // eventXX shorthand for /dev/input/eventXX
-        if filter.starts_with("event") && self.path.file_name().expect("every device path has a file name") == filter {
-            return true;
-        }
-        // Allow partial matches for device names
-        if self.name.contains(filter) {
-            return true;
-        }
-        return false;
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -133,7 +133,7 @@ pub fn get_input_devices(
     Ok(devices.into_iter().map(From::from).collect())
 }
 
-#[derive_where(PartialEq, PartialOrd, Ord)]
+#[derive_where(PartialEq, PartialOrd, Ord, Debug)]
 pub struct InputDevice {
     path: PathBuf,
     #[derive_where(skip)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -216,6 +216,12 @@ pub struct InputDeviceDescriptor {
 }
 
 impl InputDeviceDescriptor {
+    pub fn new(name: &str, path: &str) -> Self {
+        Self {
+            name: String::from(name),
+            path: PathBuf::from(path),
+        }
+    }
     pub fn matches(&self, filter: &String) -> bool {
         let filter = filter.as_str();
         // Check exact matches for explicit selection

--- a/src/device.rs
+++ b/src/device.rs
@@ -133,7 +133,7 @@ pub fn get_input_devices(
     Ok(devices.into_iter().map(From::from).collect())
 }
 
-#[derive_where(PartialEq, PartialOrd, Ord, Debug)]
+#[derive_where(PartialEq, PartialOrd, Ord)]
 pub struct InputDevice {
     path: PathBuf,
     #[derive_where(skip)]
@@ -302,7 +302,7 @@ impl InputDevice {
             Some(keys) => {
                 keys.contains(Key::KEY_SPACE)
                 && keys.contains(Key::KEY_A)
-                    && keys.contains(Key::KEY_Z)
+                && keys.contains(Key::KEY_Z)
                 // BTN_MOUSE
                 && !keys.contains(Key::BTN_LEFT)
             }

--- a/src/device.rs
+++ b/src/device.rs
@@ -201,8 +201,8 @@ impl InputDevice {
         self.device.input_id().bus_type()
     }
 
-    pub fn to_device_descriptor(&self) -> InputDeviceDescriptor {
-        InputDeviceDescriptor {
+    pub fn to_info(&self) -> InputDeviceInfo {
+        InputDeviceInfo {
             name: self.device_name().to_string(),
             path: self.path.clone(),
         }
@@ -210,12 +210,12 @@ impl InputDevice {
 }
 
 #[derive(Debug)]
-pub struct InputDeviceDescriptor {
+pub struct InputDeviceInfo {
     name: String,
     path: PathBuf,
 }
 
-impl InputDeviceDescriptor {
+impl InputDeviceInfo {
     pub fn new(name: &str, path: &str) -> Self {
         Self {
             name: String::from(name),
@@ -285,7 +285,7 @@ impl InputDevice {
     }
 
     pub fn matches(&self, filter: &String) -> bool {
-        self.to_device_descriptor().matches(filter)
+        self.to_info().matches(filter)
     }
 
     fn matches_any(&self, filter: &[String]) -> bool {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,7 @@
 use evdev::{EventType, InputEvent, Key};
 
+use crate::device::InputDevice;
+
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
 pub enum Event {
@@ -17,6 +19,7 @@ pub enum Event {
 pub struct KeyEvent {
     key: Key,
     value: KeyValue,
+    device: &InputDevice
 }
 
 #[derive(Debug)]
@@ -33,9 +36,9 @@ pub enum KeyValue {
 }
 impl Event {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(event: InputEvent) -> Event {
+    pub fn new(event: InputEvent, device: &InputDevice) -> Event {
         let event = match event.event_type() {
-            EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value())),
+            EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value(), device)),
             EventType::RELATIVE => Event::RelativeEvent(RelativeEvent::new_with(event.code(), event.value())),
             _ => Event::OtherEvents(event),
         };

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,22 +4,21 @@ use crate::device::InputDevice;
 
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
-pub enum Event {
+pub enum Event<'a> {
     // InputEvent (EventType::KEY) sent from evdev
-    KeyEvent(KeyEvent),
+    KeyEvent(&'a InputDevice, KeyEvent),
     // InputEvent (EventType::Relative) sent from evdev
-    RelativeEvent(RelativeEvent),
+    RelativeEvent(&'a InputDevice, RelativeEvent),
     // Any other InputEvent type sent from evdev
-    OtherEvents(InputEvent),
+    OtherEvents(&'a InputDevice, InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
 
 #[derive(Debug)]
 pub struct KeyEvent {
-    key: Key,
+    pub key: Key,
     value: KeyValue,
-    device: &InputDevice
 }
 
 #[derive(Debug)]
@@ -34,13 +33,13 @@ pub enum KeyValue {
     Release,
     Repeat,
 }
-impl Event {
+impl<'a> Event<'a> {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(event: InputEvent, device: &InputDevice) -> Event {
+    pub fn new(device: &'a InputDevice, event: InputEvent) -> Event<'a> {
         let event = match event.event_type() {
-            EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value(), device)),
-            EventType::RELATIVE => Event::RelativeEvent(RelativeEvent::new_with(event.code(), event.value())),
-            _ => Event::OtherEvents(event),
+            EventType::KEY => Event::KeyEvent(device, KeyEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => Event::RelativeEvent(device, RelativeEvent::new_with(event.code(), event.value())),
+            _ => Event::OtherEvents(device, event),
         };
         event
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,23 +1,21 @@
 use evdev::{EventType, InputEvent, Key};
 
-use crate::device::InputDevice;
-
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
-pub enum Event<'a> {
+pub enum Event {
     // InputEvent (EventType::KEY) sent from evdev
-    KeyEvent(&'a InputDevice, KeyEvent),
+    KeyEvent(KeyEvent),
     // InputEvent (EventType::Relative) sent from evdev
-    RelativeEvent(&'a InputDevice, RelativeEvent),
+    RelativeEvent(RelativeEvent),
     // Any other InputEvent type sent from evdev
-    OtherEvents(&'a InputDevice, InputEvent),
+    OtherEvents(InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
 
 #[derive(Debug)]
 pub struct KeyEvent {
-    pub key: Key,
+    key: Key,
     value: KeyValue,
 }
 
@@ -33,13 +31,13 @@ pub enum KeyValue {
     Release,
     Repeat,
 }
-impl<'a> Event<'a> {
+impl Event {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(device: &'a InputDevice, event: InputEvent) -> Event<'a> {
+    pub fn new(event: InputEvent) -> Event {
         let event = match event.event_type() {
-            EventType::KEY => Event::KeyEvent(device, KeyEvent::new_with(event.code(), event.value())),
-            EventType::RELATIVE => Event::RelativeEvent(device, RelativeEvent::new_with(event.code(), event.value())),
-            _ => Event::OtherEvents(device, event),
+            EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => Event::RelativeEvent(RelativeEvent::new_with(event.code(), event.value())),
+            _ => Event::OtherEvents(event),
         };
         event
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,16 +1,14 @@
 use evdev::{EventType, InputEvent, Key};
 
-use crate::device::InputDevice;
-
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
-pub enum Event<'a> {
+pub enum Event {
     // InputEvent (EventType::KEY) sent from evdev
-    KeyEvent(&'a InputDevice, KeyEvent),
+    KeyEvent(KeyEvent),
     // InputEvent (EventType::Relative) sent from evdev
-    RelativeEvent(&'a InputDevice, RelativeEvent),
+    RelativeEvent(RelativeEvent),
     // Any other InputEvent type sent from evdev
-    OtherEvents(&'a InputDevice, InputEvent),
+    OtherEvents(InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
@@ -33,13 +31,13 @@ pub enum KeyValue {
     Release,
     Repeat,
 }
-impl<'a> Event<'a> {
+impl Event {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(device: &'a InputDevice, event: InputEvent) -> Event<'a> {
+    pub fn new(event: InputEvent) -> Event {
         let event = match event.event_type() {
-            EventType::KEY => Event::KeyEvent(device, KeyEvent::new_with(event.code(), event.value())),
-            EventType::RELATIVE => Event::RelativeEvent(device, RelativeEvent::new_with(event.code(), event.value())),
-            _ => Event::OtherEvents(device, event),
+            EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => Event::RelativeEvent(RelativeEvent::new_with(event.code(), event.value())),
+            _ => Event::OtherEvents(event),
         };
         event
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 use evdev::{EventType, InputEvent, Key};
 
-use crate::device::{InputDevice, InputDeviceInfo};
+use crate::device::InputDeviceInfo;
 
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
@@ -10,7 +10,7 @@ pub enum Event<'a> {
     // InputEvent (EventType::Relative) sent from evdev
     RelativeEvent(InputDeviceInfo<'a>, RelativeEvent),
     // Any other InputEvent type sent from evdev
-    OtherEvents(InputDeviceInfo<'a>, InputEvent),
+    OtherEvents(InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
@@ -35,14 +35,11 @@ pub enum KeyValue {
 }
 impl<'a> Event<'a> {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(device: &InputDevice, event: InputEvent) -> Event {
-        let device_info = device.to_info();
+    pub fn new(device: InputDeviceInfo, event: InputEvent) -> Event {
         let event = match event.event_type() {
-            EventType::KEY => Event::KeyEvent(device_info, KeyEvent::new_with(event.code(), event.value())),
-            EventType::RELATIVE => {
-                Event::RelativeEvent(device_info, RelativeEvent::new_with(event.code(), event.value()))
-            }
-            _ => Event::OtherEvents(device_info, event),
+            EventType::KEY => Event::KeyEvent(device, KeyEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => Event::RelativeEvent(device, RelativeEvent::new_with(event.code(), event.value())),
+            _ => Event::OtherEvents(event),
         };
         event
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -33,9 +33,9 @@ pub enum KeyValue {
     Release,
     Repeat,
 }
-impl<'a> Event {
+impl Event {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(device: &'a InputDevice, event: InputEvent) -> Event {
+    pub fn new(device: &InputDevice, event: InputEvent) -> Event {
         let device_info = device.to_info();
         let event = match event.event_type() {
             EventType::KEY => Event::KeyEvent(device_info, KeyEvent::new_with(event.code(), event.value())),

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,16 +1,16 @@
 use evdev::{EventType, InputEvent, Key};
 
-use crate::device::{InputDevice, InputDeviceDescriptor};
+use crate::device::{InputDevice, InputDeviceInfo};
 
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
 pub enum Event {
     // InputEvent (EventType::KEY) sent from evdev
-    KeyEvent(InputDeviceDescriptor, KeyEvent),
+    KeyEvent(InputDeviceInfo, KeyEvent),
     // InputEvent (EventType::Relative) sent from evdev
-    RelativeEvent(InputDeviceDescriptor, RelativeEvent),
+    RelativeEvent(InputDeviceInfo, RelativeEvent),
     // Any other InputEvent type sent from evdev
-    OtherEvents(InputDeviceDescriptor, InputEvent),
+    OtherEvents(InputDeviceInfo, InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
@@ -36,11 +36,11 @@ pub enum KeyValue {
 impl<'a> Event {
     // Convert evdev's raw InputEvent to xremap's internal Event
     pub fn new(device: &'a InputDevice, event: InputEvent) -> Event {
-        let device_descriptor = device.to_device_descriptor();
+        let device_info = device.to_info();
         let event = match event.event_type() {
-            EventType::KEY => Event::KeyEvent(device_descriptor, KeyEvent::new_with(event.code(), event.value())),
-            EventType::RELATIVE => Event::RelativeEvent(device_descriptor, RelativeEvent::new_with(event.code(), event.value())),
-            _ => Event::OtherEvents(device_descriptor, event),
+            EventType::KEY => Event::KeyEvent(device_info, KeyEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => Event::RelativeEvent(device_info, RelativeEvent::new_with(event.code(), event.value())),
+            _ => Event::OtherEvents(device_info, event),
         };
         event
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,14 +1,16 @@
 use evdev::{EventType, InputEvent, Key};
 
+use crate::device::InputDevice;
+
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
-pub enum Event {
+pub enum Event<'a> {
     // InputEvent (EventType::KEY) sent from evdev
-    KeyEvent(KeyEvent),
+    KeyEvent(&'a InputDevice, KeyEvent),
     // InputEvent (EventType::Relative) sent from evdev
-    RelativeEvent(RelativeEvent),
+    RelativeEvent(&'a InputDevice, RelativeEvent),
     // Any other InputEvent type sent from evdev
-    OtherEvents(InputEvent),
+    OtherEvents(&'a InputDevice, InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
@@ -31,13 +33,13 @@ pub enum KeyValue {
     Release,
     Repeat,
 }
-impl Event {
+impl<'a> Event<'a> {
     // Convert evdev's raw InputEvent to xremap's internal Event
-    pub fn new(event: InputEvent) -> Event {
+    pub fn new(device: &'a InputDevice, event: InputEvent) -> Event<'a> {
         let event = match event.event_type() {
-            EventType::KEY => Event::KeyEvent(KeyEvent::new_with(event.code(), event.value())),
-            EventType::RELATIVE => Event::RelativeEvent(RelativeEvent::new_with(event.code(), event.value())),
-            _ => Event::OtherEvents(event),
+            EventType::KEY => Event::KeyEvent(device, KeyEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => Event::RelativeEvent(device, RelativeEvent::new_with(event.code(), event.value())),
+            _ => Event::OtherEvents(device, event),
         };
         event
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,13 +4,13 @@ use crate::device::{InputDevice, InputDeviceInfo};
 
 // Input to EventHandler. This should only contain things that are easily testable.
 #[derive(Debug)]
-pub enum Event {
+pub enum Event<'a> {
     // InputEvent (EventType::KEY) sent from evdev
-    KeyEvent(InputDeviceInfo, KeyEvent),
+    KeyEvent(InputDeviceInfo<'a>, KeyEvent),
     // InputEvent (EventType::Relative) sent from evdev
-    RelativeEvent(InputDeviceInfo, RelativeEvent),
+    RelativeEvent(InputDeviceInfo<'a>, RelativeEvent),
     // Any other InputEvent type sent from evdev
-    OtherEvents(InputDeviceInfo, InputEvent),
+    OtherEvents(InputDeviceInfo<'a>, InputEvent),
     // Timer for nested override reached its timeout
     OverrideTimeout,
 }
@@ -33,13 +33,15 @@ pub enum KeyValue {
     Release,
     Repeat,
 }
-impl Event {
+impl<'a> Event<'a> {
     // Convert evdev's raw InputEvent to xremap's internal Event
     pub fn new(device: &InputDevice, event: InputEvent) -> Event {
         let device_info = device.to_info();
         let event = match event.event_type() {
             EventType::KEY => Event::KeyEvent(device_info, KeyEvent::new_with(event.code(), event.value())),
-            EventType::RELATIVE => Event::RelativeEvent(device_info, RelativeEvent::new_with(event.code(), event.value())),
+            EventType::RELATIVE => {
+                Event::RelativeEvent(device_info, RelativeEvent::new_with(event.code(), event.value()))
+            }
             _ => Event::OtherEvents(device_info, event),
         };
         event

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -8,7 +8,7 @@ use crate::config::modmap_action::{Keys, ModmapAction, MultiPurposeKey, PressRel
 use crate::config::remap::Remap;
 use crate::device::InputDevice;
 use crate::event::{Event, KeyEvent, RelativeEvent};
-use crate::Config;
+use crate::{Config, config};
 use evdev::Key;
 use lazy_static::lazy_static;
 use log::debug;
@@ -87,11 +87,11 @@ impl EventHandler {
         for event in events {
             match event {
                 Event::KeyEvent(device, key_event) => {
-                    self.on_key_event(key_event, config)?;
+                    self.on_key_event(key_event, config, device)?;
                     ()
                 }
                 Event::RelativeEvent(device, relative_event) => {
-                    self.on_relative_event(relative_event, &mut mouse_movement_collection, config)?
+                    self.on_relative_event(relative_event, &mut mouse_movement_collection, config, device)?
                 }
 
                 Event::OtherEvents(device, event) => self.send_action(Action::InputEvent(*event)),
@@ -106,13 +106,13 @@ impl EventHandler {
     }
 
     // Handle EventType::KEY
-    fn on_key_event(&mut self, event: &KeyEvent, config: &Config) -> Result<bool, Box<dyn Error>> {
+    fn on_key_event(&mut self, event: &KeyEvent, config: &Config, device: &InputDevice) -> Result<bool, Box<dyn Error>> {
         self.application_cache = None; // expire cache
         let key = Key::new(event.code());
         debug!("=> {}: {:?}", event.value(), &key);
 
         // Apply modmap
-        let mut key_values = if let Some(key_action) = self.find_modmap(config, &key) {
+        let mut key_values = if let Some(key_action) = self.find_modmap(config, &key, device) {
             self.dispatch_keys(key_action, key, event.value())?
         } else {
             vec![(key, event.value())]
@@ -133,7 +133,7 @@ impl EventHandler {
             } else if is_pressed(value) {
                 if self.escape_next_key {
                     self.escape_next_key = false
-                } else if let Some(actions) = self.find_keymap(config, event)? {
+                } else if let Some(actions) = self.find_keymap(config, event, device)? {
                     self.dispatch_actions(&actions, &key)?;
                     continue;
                 }
@@ -160,6 +160,7 @@ impl EventHandler {
         event: &RelativeEvent,
         mouse_movement_collection: &mut Vec<RelativeEvent>,
         config: &Config,
+        device: &InputDevice
     ) -> Result<(), Box<dyn Error>> {
         // Because a "full" RELATIVE event is only one event,
         // it doesn't translate very well into a KEY event (because those have a "press" event and an "unpress" event).
@@ -201,7 +202,7 @@ impl EventHandler {
         };
 
         // Sending a RELATIVE event "disguised" as a "fake" KEY event press to on_key_event.
-        match self.on_key_event(&KeyEvent::new_with(key, PRESS), config)? {
+        match self.on_key_event(&KeyEvent::new_with(key, PRESS), config, device)? {
             // the boolean value is from a variable at the end of on_key_event from event_handler,
             // used to indicate whether the event got through unchanged.
             true => {
@@ -230,7 +231,7 @@ impl EventHandler {
         }
 
         // Sending the "unpressed" version of the "fake" KEY event.
-        self.on_key_event(&KeyEvent::new_with(key, RELEASE), config)?;
+        self.on_key_event(&KeyEvent::new_with(key, RELEASE), config, device)?;
 
         Ok(())
     }
@@ -366,11 +367,16 @@ impl EventHandler {
         }
     }
 
-    fn find_modmap(&mut self, config: &Config, key: &Key) -> Option<ModmapAction> {
+    fn find_modmap(&mut self, config: &Config, key: &Key, device: &InputDevice) -> Option<ModmapAction> {
         for modmap in &config.modmap {
             if let Some(key_action) = modmap.remap.get(key) {
                 if let Some(application_matcher) = &modmap.application {
                     if !self.match_application(application_matcher) {
+                        continue;
+                    }
+                }
+                if let Some(device_matcher) = &modmap.device {
+                    if !self.match_device(device_matcher, device) {
                         continue;
                     }
                 }
@@ -380,7 +386,7 @@ impl EventHandler {
         None
     }
 
-    fn find_keymap(&mut self, config: &Config, event: &KeyEvent) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
+    fn find_keymap(&mut self, config: &Config, event: &KeyEvent, device: &InputDevice) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
         if !self.override_remaps.is_empty() {
             let entries: Vec<OverrideEntry> = self
                 .override_remaps
@@ -434,6 +440,11 @@ impl EventHandler {
                     }
                     if let Some(application_matcher) = &entry.application {
                         if !self.match_application(application_matcher) {
+                            continue;
+                        }
+                    }
+                    if let Some(device_matcher) = &entry.device {
+                        if !self.match_device(device_matcher, device) {
                             continue;
                         }
                     }
@@ -613,6 +624,16 @@ impl EventHandler {
         false
     }
 
+    fn match_device(&self, device_matcher: &config::device::Device, device: &InputDevice) -> bool {
+        if let Some(device_only) = &self.device_matcher.only {
+            return device_only.iter().any(|m| m.matches(device));
+        }
+        if let Some(device_not) = &self.device_matcher.not {
+            return device_not.iter().all(|m| !m.matches(device));
+        }
+        true
+    }
+
     fn update_modifier(&mut self, key: Key, value: i32) {
         if value == PRESS {
             self.modifiers.insert(key);
@@ -620,6 +641,7 @@ impl EventHandler {
             self.modifiers.remove(&key);
         }
     }
+
 }
 
 fn is_remap(actions: &Vec<KeymapAction>) -> bool {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -631,7 +631,7 @@ impl EventHandler {
         if let Some(device_not) = &device_matcher.not {
             return device_not.iter().all(|m| device.matches(m));
         }
-        true
+        false
     }
 
     fn update_modifier(&mut self, key: Key, value: i32) {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -94,7 +94,7 @@ impl EventHandler {
                     self.on_relative_event(relative_event, &mut mouse_movement_collection, config, device)?
                 }
 
-                Event::OtherEvents(_device, event) => self.send_action(Action::InputEvent(*event)),
+                Event::OtherEvents(event) => self.send_action(Action::InputEvent(*event)),
                 Event::OverrideTimeout => self.timeout_override()?,
             };
         }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -629,7 +629,7 @@ impl EventHandler {
             return device_only.iter().any(|m| device.matches(m));
         }
         if let Some(device_not) = &device_matcher.not {
-            return device_not.iter().all(|m| device.matches(m));
+            return device_not.iter().all(|m| !device.matches(m));
         }
         false
     }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -81,20 +81,20 @@ impl EventHandler {
     }
 
     // Handle an Event and return Actions. This should be the only public method of EventHandler.
-    pub fn on_events(&mut self, events: &Vec<Event>, config: &Config) -> Result<Vec<Action>, Box<dyn Error>> {
+    pub fn on_events(&mut self, events: &Vec<Event>, config: &Config, device: &InputDevice) -> Result<Vec<Action>, Box<dyn Error>> {
         // a vector to collect mouse movement events to be able to send them all at once as one MouseMovementEventCollection.
         let mut mouse_movement_collection: Vec<RelativeEvent> = Vec::new();
         for event in events {
             match event {
-                Event::KeyEvent(device, key_event) => {
+                Event::KeyEvent(key_event) => {
                     self.on_key_event(key_event, config, device)?;
                     ()
                 }
-                Event::RelativeEvent(device, relative_event) => {
+                Event::RelativeEvent(relative_event) => {
                     self.on_relative_event(relative_event, &mut mouse_movement_collection, config, device)?
                 }
 
-                Event::OtherEvents(_device, event) => self.send_action(Action::InputEvent(*event)),
+                Event::OtherEvents(event) => self.send_action(Action::InputEvent(*event)),
                 Event::OverrideTimeout => self.timeout_override()?,
             };
         }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -8,7 +8,7 @@ use crate::config::modmap_action::{Keys, ModmapAction, MultiPurposeKey, PressRel
 use crate::config::remap::Remap;
 use crate::device::InputDeviceInfo;
 use crate::event::{Event, KeyEvent, RelativeEvent};
-use crate::{Config, config};
+use crate::{config, Config};
 use evdev::Key;
 use lazy_static::lazy_static;
 use log::debug;
@@ -106,7 +106,12 @@ impl EventHandler {
     }
 
     // Handle EventType::KEY
-    fn on_key_event(&mut self, event: &KeyEvent, config: &Config, device: &InputDeviceInfo) -> Result<bool, Box<dyn Error>> {
+    fn on_key_event(
+        &mut self,
+        event: &KeyEvent,
+        config: &Config,
+        device: &InputDeviceInfo,
+    ) -> Result<bool, Box<dyn Error>> {
         self.application_cache = None; // expire cache
         let key = Key::new(event.code());
         debug!("=> {}: {:?}", event.value(), &key);
@@ -160,7 +165,7 @@ impl EventHandler {
         event: &RelativeEvent,
         mouse_movement_collection: &mut Vec<RelativeEvent>,
         config: &Config,
-        device: &InputDeviceInfo
+        device: &InputDeviceInfo,
     ) -> Result<(), Box<dyn Error>> {
         // Because a "full" RELATIVE event is only one event,
         // it doesn't translate very well into a KEY event (because those have a "press" event and an "unpress" event).
@@ -386,7 +391,12 @@ impl EventHandler {
         None
     }
 
-    fn find_keymap(&mut self, config: &Config, key: &Key, device: &InputDeviceInfo) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
+    fn find_keymap(
+        &mut self,
+        config: &Config,
+        key: &Key,
+        device: &InputDeviceInfo,
+    ) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
         if !self.override_remaps.is_empty() {
             let entries: Vec<OverrideEntry> = self
                 .override_remaps

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -81,20 +81,20 @@ impl EventHandler {
     }
 
     // Handle an Event and return Actions. This should be the only public method of EventHandler.
-    pub fn on_events(&mut self, events: &Vec<Event>, config: &Config, device: &InputDevice) -> Result<Vec<Action>, Box<dyn Error>> {
+    pub fn on_events(&mut self, events: &Vec<Event>, config: &Config) -> Result<Vec<Action>, Box<dyn Error>> {
         // a vector to collect mouse movement events to be able to send them all at once as one MouseMovementEventCollection.
         let mut mouse_movement_collection: Vec<RelativeEvent> = Vec::new();
         for event in events {
             match event {
-                Event::KeyEvent(key_event) => {
+                Event::KeyEvent(device, key_event) => {
                     self.on_key_event(key_event, config, device)?;
                     ()
                 }
-                Event::RelativeEvent(relative_event) => {
+                Event::RelativeEvent(device, relative_event) => {
                     self.on_relative_event(relative_event, &mut mouse_movement_collection, config, device)?
                 }
 
-                Event::OtherEvents(event) => self.send_action(Action::InputEvent(*event)),
+                Event::OtherEvents(_device, event) => self.send_action(Action::InputEvent(*event)),
                 Event::OverrideTimeout => self.timeout_override()?,
             };
         }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -6,7 +6,7 @@ use crate::config::keymap::{build_override_table, OverrideEntry};
 use crate::config::keymap_action::KeymapAction;
 use crate::config::modmap_action::{Keys, ModmapAction, MultiPurposeKey, PressReleaseKey};
 use crate::config::remap::Remap;
-use crate::device::InputDeviceDescriptor;
+use crate::device::InputDeviceInfo;
 use crate::event::{Event, KeyEvent, RelativeEvent};
 use crate::{Config, config};
 use evdev::Key;
@@ -106,7 +106,7 @@ impl EventHandler {
     }
 
     // Handle EventType::KEY
-    fn on_key_event(&mut self, event: &KeyEvent, config: &Config, device: &InputDeviceDescriptor) -> Result<bool, Box<dyn Error>> {
+    fn on_key_event(&mut self, event: &KeyEvent, config: &Config, device: &InputDeviceInfo) -> Result<bool, Box<dyn Error>> {
         self.application_cache = None; // expire cache
         let key = Key::new(event.code());
         debug!("=> {}: {:?}", event.value(), &key);
@@ -160,7 +160,7 @@ impl EventHandler {
         event: &RelativeEvent,
         mouse_movement_collection: &mut Vec<RelativeEvent>,
         config: &Config,
-        device: &InputDeviceDescriptor
+        device: &InputDeviceInfo
     ) -> Result<(), Box<dyn Error>> {
         // Because a "full" RELATIVE event is only one event,
         // it doesn't translate very well into a KEY event (because those have a "press" event and an "unpress" event).
@@ -367,7 +367,7 @@ impl EventHandler {
         }
     }
 
-    fn find_modmap(&mut self, config: &Config, key: &Key, device: &InputDeviceDescriptor) -> Option<ModmapAction> {
+    fn find_modmap(&mut self, config: &Config, key: &Key, device: &InputDeviceInfo) -> Option<ModmapAction> {
         for modmap in &config.modmap {
             if let Some(key_action) = modmap.remap.get(key) {
                 if let Some(application_matcher) = &modmap.application {
@@ -386,7 +386,7 @@ impl EventHandler {
         None
     }
 
-    fn find_keymap(&mut self, config: &Config, event: &KeyEvent, device: &InputDeviceDescriptor) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
+    fn find_keymap(&mut self, config: &Config, event: &KeyEvent, device: &InputDeviceInfo) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
         if !self.override_remaps.is_empty() {
             let entries: Vec<OverrideEntry> = self
                 .override_remaps
@@ -624,7 +624,7 @@ impl EventHandler {
         false
     }
 
-    fn match_device(&self, device_matcher: &config::device::Device, device: &InputDeviceDescriptor) -> bool {
+    fn match_device(&self, device_matcher: &config::device::Device, device: &InputDeviceInfo) -> bool {
         if let Some(device_only) = &device_matcher.only {
             return device_only.iter().any(|m| device.matches(m));
         }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -94,7 +94,7 @@ impl EventHandler {
                     self.on_relative_event(relative_event, &mut mouse_movement_collection, config, device)?
                 }
 
-                Event::OtherEvents(device, event) => self.send_action(Action::InputEvent(*event)),
+                Event::OtherEvents(_device, event) => self.send_action(Action::InputEvent(*event)),
                 Event::OverrideTimeout => self.timeout_override()?,
             };
         }
@@ -625,11 +625,11 @@ impl EventHandler {
     }
 
     fn match_device(&self, device_matcher: &config::device::Device, device: &InputDevice) -> bool {
-        if let Some(device_only) = &self.device_matcher.only {
-            return device_only.iter().any(|m| m.matches(device));
+        if let Some(device_only) = &device_matcher.only {
+            return device_only.iter().any(|m| device.matches(m));
         }
-        if let Some(device_not) = &self.device_matcher.not {
-            return device_not.iter().all(|m| !m.matches(device));
+        if let Some(device_not) = &device_matcher.not {
+            return device_not.iter().all(|m| device.matches(m));
         }
         true
     }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -81,20 +81,20 @@ impl EventHandler {
     }
 
     // Handle an Event and return Actions. This should be the only public method of EventHandler.
-    pub fn on_events(&mut self, events: &Vec<Event>, config: &Config) -> Result<Vec<Action>, Box<dyn Error>> {
+    pub fn on_events(&mut self, events: &Vec<Event>, config: &Config, input_device: &InputDevice) -> Result<Vec<Action>, Box<dyn Error>> {
         // a vector to collect mouse movement events to be able to send them all at once as one MouseMovementEventCollection.
         let mut mouse_movement_collection: Vec<RelativeEvent> = Vec::new();
         for event in events {
             match event {
-                Event::KeyEvent(device, key_event) => {
-                    self.on_key_event(key_event, config)?;
+                Event::KeyEvent(key_event) => {
+                    self.on_key_event(key_event, config, input_device)?;
                     ()
                 }
-                Event::RelativeEvent(device, relative_event) => {
-                    self.on_relative_event(relative_event, &mut mouse_movement_collection, config)?
+                Event::RelativeEvent(relative_event) => {
+                    self.on_relative_event(relative_event, &mut mouse_movement_collection, config, input_device)?
                 }
 
-                Event::OtherEvents(device, event) => self.send_action(Action::InputEvent(*event)),
+                Event::OtherEvents(event) => self.send_action(Action::InputEvent(*event)),
                 Event::OverrideTimeout => self.timeout_override()?,
             };
         }
@@ -106,13 +106,13 @@ impl EventHandler {
     }
 
     // Handle EventType::KEY
-    fn on_key_event(&mut self, event: &KeyEvent, config: &Config) -> Result<bool, Box<dyn Error>> {
+    fn on_key_event(&mut self, event: &KeyEvent, config: &Config, input_device: &InputDevice) -> Result<bool, Box<dyn Error>> {
         self.application_cache = None; // expire cache
         let key = Key::new(event.code());
         debug!("=> {}: {:?}", event.value(), &key);
 
         // Apply modmap
-        let mut key_values = if let Some(key_action) = self.find_modmap(config, &key) {
+        let mut key_values = if let Some(key_action) = self.find_modmap(config, &key, input_device) {
             self.dispatch_keys(key_action, key, event.value())?
         } else {
             vec![(key, event.value())]
@@ -133,7 +133,7 @@ impl EventHandler {
             } else if is_pressed(value) {
                 if self.escape_next_key {
                     self.escape_next_key = false
-                } else if let Some(actions) = self.find_keymap(config, event)? {
+                } else if let Some(actions) = self.find_keymap(config, &key, input_device)? {
                     self.dispatch_actions(&actions, &key)?;
                     continue;
                 }
@@ -160,6 +160,7 @@ impl EventHandler {
         event: &RelativeEvent,
         mouse_movement_collection: &mut Vec<RelativeEvent>,
         config: &Config,
+        input_device: &InputDevice
     ) -> Result<(), Box<dyn Error>> {
         // Because a "full" RELATIVE event is only one event,
         // it doesn't translate very well into a KEY event (because those have a "press" event and an "unpress" event).
@@ -201,7 +202,7 @@ impl EventHandler {
         };
 
         // Sending a RELATIVE event "disguised" as a "fake" KEY event press to on_key_event.
-        match self.on_key_event(&KeyEvent::new_with(key, PRESS), config)? {
+        match self.on_key_event(&KeyEvent::new_with(key, PRESS), config, input_device)? {
             // the boolean value is from a variable at the end of on_key_event from event_handler,
             // used to indicate whether the event got through unchanged.
             true => {
@@ -230,7 +231,7 @@ impl EventHandler {
         }
 
         // Sending the "unpressed" version of the "fake" KEY event.
-        self.on_key_event(&KeyEvent::new_with(key, RELEASE), config)?;
+        self.on_key_event(&KeyEvent::new_with(key, RELEASE), config, input_device)?;
 
         Ok(())
     }
@@ -366,7 +367,7 @@ impl EventHandler {
         }
     }
 
-    fn find_modmap(&mut self, config: &Config, key: &Key) -> Option<ModmapAction> {
+    fn find_modmap(&mut self, config: &Config, key: &Key, input_device: &InputDevice) -> Option<ModmapAction> {
         for modmap in &config.modmap {
             if let Some(key_action) = modmap.remap.get(key) {
                 if let Some(application_matcher) = &modmap.application {
@@ -380,12 +381,12 @@ impl EventHandler {
         None
     }
 
-    fn find_keymap(&mut self, config: &Config, event: &KeyEvent) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
+    fn find_keymap(&mut self, config: &Config, key: &Key, input_device: &InputDevice) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
         if !self.override_remaps.is_empty() {
             let entries: Vec<OverrideEntry> = self
                 .override_remaps
                 .iter()
-                .flat_map(|map| map.get(&event.key).cloned().unwrap_or_default())
+                .flat_map(|map| map.get(key).cloned().unwrap_or_default())
                 .collect();
 
             if !entries.is_empty() {
@@ -421,7 +422,7 @@ impl EventHandler {
             self.timeout_override()?;
         }
 
-        if let Some(entries) = config.keymap_table.get(&event.key) {
+        if let Some(entries) = config.keymap_table.get(key) {
             for exact_match in [true, false] {
                 let mut remaps = vec![];
                 for entry in entries {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -133,7 +133,7 @@ impl EventHandler {
             } else if is_pressed(value) {
                 if self.escape_next_key {
                     self.escape_next_key = false
-                } else if let Some(actions) = self.find_keymap(config, event, device)? {
+                } else if let Some(actions) = self.find_keymap(config, &key, device)? {
                     self.dispatch_actions(&actions, &key)?;
                     continue;
                 }
@@ -386,12 +386,12 @@ impl EventHandler {
         None
     }
 
-    fn find_keymap(&mut self, config: &Config, event: &KeyEvent, device: &InputDeviceInfo) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
+    fn find_keymap(&mut self, config: &Config, key: &Key, device: &InputDeviceInfo) -> Result<Option<Vec<TaggedAction>>, Box<dyn Error>> {
         if !self.override_remaps.is_empty() {
             let entries: Vec<OverrideEntry> = self
                 .override_remaps
                 .iter()
-                .flat_map(|map| map.get(&event.key).cloned().unwrap_or_default())
+                .flat_map(|map| map.get(key).cloned().unwrap_or_default())
                 .collect();
 
             if !entries.is_empty() {
@@ -427,7 +427,7 @@ impl EventHandler {
             self.timeout_override()?;
         }
 
-        if let Some(entries) = config.keymap_table.get(&event.key) {
+        if let Some(entries) = config.keymap_table.get(key) {
             for exact_match in [true, false] {
                 let mut remaps = vec![];
                 for entry in entries {
@@ -641,7 +641,6 @@ impl EventHandler {
             self.modifiers.remove(&key);
         }
     }
-
 }
 
 fn is_remap(actions: &Vec<KeymapAction>) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ fn handle_input_events(
         Ok(events) => {
             let mut input_events: Vec<Event> = Vec::new();
             for event in events {
-                let event = Event::new(event);
+                let event = Event::new(event, input_device);
                 input_events.push(event);
             }
             handle_events(handler, dispatcher, config, input_events)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,11 +133,12 @@ fn main() -> anyhow::Result<()> {
         match 'event_loop: loop {
             let readable_fds = select_readable(input_devices.values(), &watchers, timer_fd)?;
             if readable_fds.contains(timer_fd) {
-                if let Err(error) =
-                    handle_events(&mut handler, &mut dispatcher, &mut config, vec![Event::OverrideTimeout])
-                {
-                    println!("Error on remap timeout: {error}")
-                }
+                // TODO
+                // if let Err(error) =
+                //     handle_events(&mut handler, &mut dispatcher, &mut config, vec![Event::OverrideTimeout])
+                // {
+                //     println!("Error on remap timeout: {error}")
+                // }
             }
 
             for input_device in input_devices.values_mut() {
@@ -236,8 +237,8 @@ fn handle_input_events(
         Err((_, error)) => Err(error).context("Error fetching input events"),
         Ok(events) => Ok(events.collect())
     }?;
-    let input_events = events.iter().map(|e| Event::new(input_device, *e)).collect();
-    handle_events(handler, dispatcher, config, input_events)?;
+    let input_events = events.iter().map(|e| Event::new(*e)).collect();
+    handle_events(handler, dispatcher, config, input_events, input_device)?;
     Ok(device_exists)
 }
 
@@ -247,9 +248,10 @@ fn handle_events(
     dispatcher: &mut ActionDispatcher,
     config: &mut Config,
     events: Vec<Event>,
+    device: &InputDevice
 ) -> anyhow::Result<()> {
     let actions = handler
-        .on_events(&events, config)
+        .on_events(&events, config, device)
         .map_err(|e| anyhow!("Failed handling {events:?}:\n  {e:?}"))?;
     for action in actions {
         dispatcher.on_action(action)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ fn handle_input_events(
         Err((_, error)) => Err(error).context("Error fetching input events"),
         Ok(events) => Ok(events.collect()),
     }?;
-    let input_events = events.iter().map(|e| Event::new(input_device, *e)).collect();
+    let input_events = events.iter().map(|e| Event::new(input_device.to_info(), *e)).collect();
     handle_events(handler, dispatcher, config, input_events)?;
     Ok(device_exists)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ fn handle_input_events(
         Ok(events) => {
             let mut input_events: Vec<Event> = Vec::new();
             for event in events {
-                let event = Event::new(event, input_device);
+                let event = Event::new(input_device, event);
                 input_events.push(event);
             }
             handle_events(handler, dispatcher, config, input_events)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,7 +227,6 @@ fn handle_input_events(
     config: &mut Config,
 ) -> anyhow::Result<bool> {
     let mut device_exists = true;
-    // TODO: avoid double collect?
     let events = match input_device.fetch_events().map_err(|e| (e.raw_os_error(), e)) {
         Err((Some(ENODEV), _)) => {
             device_exists = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,11 +133,12 @@ fn main() -> anyhow::Result<()> {
         match 'event_loop: loop {
             let readable_fds = select_readable(input_devices.values(), &watchers, timer_fd)?;
             if readable_fds.contains(timer_fd) {
-                if let Err(error) =
-                    handle_events(&mut handler, &mut dispatcher, &mut config, vec![Event::OverrideTimeout])
-                {
-                    println!("Error on remap timeout: {error}")
-                }
+                // TODO
+                // if let Err(error) =
+                //     handle_events(&mut handler, &mut dispatcher, &mut config, vec![Event::OverrideTimeout])
+                // {
+                //     println!("Error on remap timeout: {error}")
+                // }
             }
 
             for input_device in input_devices.values_mut() {
@@ -232,10 +233,10 @@ fn handle_input_events(
         Ok(events) => {
             let mut input_events: Vec<Event> = Vec::new();
             for event in events {
-                let event = Event::new(input_device, event);
+                let event = Event::new(event);
                 input_events.push(event);
             }
-            handle_events(handler, dispatcher, config, input_events)?;
+            handle_events(input_device, handler, dispatcher, config, input_events)?;
 
             Ok(true)
         }
@@ -244,13 +245,14 @@ fn handle_input_events(
 
 // Handle an Event with EventHandler, and dispatch Actions with ActionDispatcher
 fn handle_events(
+    input_device: &InputDevice,
     handler: &mut EventHandler,
     dispatcher: &mut ActionDispatcher,
     config: &mut Config,
     events: Vec<Event>,
 ) -> anyhow::Result<()> {
     let actions = handler
-        .on_events(&events, config)
+        .on_events(&events, config, input_device)
         .map_err(|e| anyhow!("Failed handling {events:?}:\n  {e:?}"))?;
     for action in actions {
         dispatcher.on_action(action)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,9 +231,9 @@ fn handle_input_events(
         Err((Some(ENODEV), _)) => {
             device_exists = false;
             Ok(Vec::new())
-        },
+        }
         Err((_, error)) => Err(error).context("Error fetching input events"),
-        Ok(events) => Ok(events.collect())
+        Ok(events) => Ok(events.collect()),
     }?;
     let input_events = events.iter().map(|e| Event::new(input_device, *e)).collect();
     handle_events(handler, dispatcher, config, input_events)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,12 +133,11 @@ fn main() -> anyhow::Result<()> {
         match 'event_loop: loop {
             let readable_fds = select_readable(input_devices.values(), &watchers, timer_fd)?;
             if readable_fds.contains(timer_fd) {
-                // TODO
-                // if let Err(error) =
-                //     handle_events(&mut handler, &mut dispatcher, &mut config, vec![Event::OverrideTimeout])
-                // {
-                //     println!("Error on remap timeout: {error}")
-                // }
+                if let Err(error) =
+                    handle_events(&mut handler, &mut dispatcher, &mut config, vec![Event::OverrideTimeout])
+                {
+                    println!("Error on remap timeout: {error}")
+                }
             }
 
             for input_device in input_devices.values_mut() {
@@ -237,8 +236,8 @@ fn handle_input_events(
         Err((_, error)) => Err(error).context("Error fetching input events"),
         Ok(events) => Ok(events.collect())
     }?;
-    let input_events = events.iter().map(|e| Event::new(*e)).collect();
-    handle_events(handler, dispatcher, config, input_events, input_device)?;
+    let input_events = events.iter().map(|e| Event::new(input_device, *e)).collect();
+    handle_events(handler, dispatcher, config, input_events)?;
     Ok(device_exists)
 }
 
@@ -248,10 +247,9 @@ fn handle_events(
     dispatcher: &mut ActionDispatcher,
     config: &mut Config,
     events: Vec<Event>,
-    device: &InputDevice
 ) -> anyhow::Result<()> {
     let actions = handler
-        .on_events(&events, config, device)
+        .on_events(&events, config)
         .map_err(|e| anyhow!("Failed handling {events:?}:\n  {e:?}"))?;
     for action in actions {
         dispatcher.on_action(action)?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -29,13 +29,8 @@ impl Client for StaticClient {
     }
 }
 
-use crate::device::get_input_devices;
 fn get_input_device<'a> () -> InputDevice {
-    let mut input_devices = match get_input_devices(&[String::from("/dev/input/event25")], &[], true, false) {
-        Ok(input_devices) => input_devices,
-        Err(e) => panic!("Failed to prepare input devices: {}", e),
-    };
-    input_devices.remove(&PathBuf::from("/dev/input/event25")).unwrap()
+    // return mock??
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,7 +28,7 @@ impl Client for StaticClient {
     }
 }
 
-fn get_input_device_info<'a>() -> InputDeviceInfo {
+fn get_input_device_info() -> InputDeviceInfo {
     InputDeviceInfo::new("Some Device", "/dev/input/event0")
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,6 @@ use evdev::InputEvent;
 use evdev::Key;
 use indoc::indoc;
 use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
-use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::client::{Client, WMClient};
@@ -43,10 +42,10 @@ fn test_basic_modmap() {
               a: b
         "},
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_A, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_A, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_B, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
@@ -101,7 +100,7 @@ fn test_relative_events() {
           - remap:
               XRIGHTCURSOR: b
         "},
-        vec![Event::RelativeEvent(&input_device, RelativeEvent::new_with(_REL_X, _POSITIVE))],
+        vec![Event::RelativeEvent(RelativeEvent::new_with(_REL_X, _POSITIVE))],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
@@ -131,8 +130,8 @@ fn test_mouse_movement_event_accumulation() {
     assert_actions(
         indoc! {""},
         vec![
-            Event::RelativeEvent(&input_device, RelativeEvent::new_with(_REL_X, _POSITIVE)),
-            Event::RelativeEvent(&input_device, RelativeEvent::new_with(_REL_Y, _POSITIVE)),
+            Event::RelativeEvent(RelativeEvent::new_with(_REL_X, _POSITIVE)),
+            Event::RelativeEvent(RelativeEvent::new_with(_REL_Y, _POSITIVE)),
         ],
         vec![Action::MouseMovementEventCollection(vec![
             RelativeEvent::new_with(_REL_X, _POSITIVE),
@@ -253,7 +252,6 @@ fn test_cursor_behavior_2() {
 
 #[test]
 fn test_interleave_modifiers() {
-    let input_device = get_input_device();
     assert_actions(
         indoc! {"
         keymap:
@@ -261,8 +259,8 @@ fn test_interleave_modifiers() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -289,9 +287,9 @@ fn test_exact_match_true() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -312,9 +310,9 @@ fn test_exact_match_false() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -341,9 +339,9 @@ fn test_exact_match_default() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -373,12 +371,12 @@ fn test_exact_match_true_nested() {
                   h: C-a
         "},
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -403,12 +401,12 @@ fn test_exact_match_false_nested() {
                   h: C-a
         "},
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -444,7 +442,7 @@ fn test_application_override() {
     let input_device = get_input_device();
     assert_actions(
         config,
-        vec![Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_A, KeyValue::Press))],
+        vec![Event::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press))],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
@@ -458,7 +456,7 @@ fn test_application_override() {
     assert_actions_with_current_application(
         config,
         Some(String::from("firefox")),
-        vec![Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_A, KeyValue::Press))],
+        vec![Event::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press))],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Press)),
@@ -488,11 +486,11 @@ fn test_merge_remaps() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -510,11 +508,11 @@ fn test_merge_remaps() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_K, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_K, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -549,11 +547,11 @@ fn test_merge_remaps_with_override() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -571,11 +569,11 @@ fn test_merge_remaps_with_override() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(&input_device, KeyEvent::new(Key::KEY_C, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -612,7 +610,8 @@ fn assert_actions_with_current_application(
     );
     let mut actual: Vec<Action> = vec![];
 
-    actual.append(&mut event_handler.on_events(&events, &config).unwrap());
+    let input_device = get_input_device();
+    actual.append(&mut event_handler.on_events(&events, &config, &input_device).unwrap());
 
     assert_eq!(format!("{:?}", actions), format!("{:?}", actual));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@ use evdev::InputEvent;
 use evdev::Key;
 use indoc::indoc;
 use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
+use std::path::Path;
 use std::time::Duration;
 
 use crate::client::{Client, WMClient};
@@ -28,8 +29,11 @@ impl Client for StaticClient {
     }
 }
 
-fn get_input_device_info() -> InputDeviceInfo {
-    InputDeviceInfo::new("Some Device", "/dev/input/event0")
+fn get_input_device_info<'a>() -> InputDeviceInfo<'a> {
+    InputDeviceInfo {
+        name: "Some Device",
+        path: &Path::new("/dev/input/event0"),
+    }
 }
 
 #[test]
@@ -487,7 +491,10 @@ fn test_device_override() {
     assert_actions(
         config,
         vec![Event::KeyEvent(
-            InputDeviceInfo::new("Some Device", "/dev/input/event0"),
+            InputDeviceInfo {
+                name: "Some Device",
+                path: &Path::new("/dev/input/event0"),
+            },
             KeyEvent::new(Key::KEY_A, KeyValue::Press),
         )],
         vec![
@@ -503,7 +510,10 @@ fn test_device_override() {
     assert_actions(
         config,
         vec![Event::KeyEvent(
-            InputDeviceInfo::new("Some Device", "/dev/input/event1"),
+            InputDeviceInfo {
+                name: "Other Device",
+                path: &Path::new("/dev/input/event1"),
+            },
             KeyEvent::new(Key::KEY_A, KeyValue::Press),
         )],
         vec![

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,7 +6,7 @@ use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
 use std::time::Duration;
 
 use crate::client::{Client, WMClient};
-use crate::device::InputDeviceDescriptor;
+use crate::device::InputDeviceInfo;
 use crate::{
     action::Action,
     config::{keymap::build_keymap_table, Config},
@@ -28,8 +28,8 @@ impl Client for StaticClient {
     }
 }
 
-fn get_input_device<'a> () -> InputDeviceDescriptor {
-    InputDeviceDescriptor::new("hi", "/dev/input/hi")
+fn get_input_device_info<'a>() -> InputDeviceInfo {
+    InputDeviceInfo::new("hi", "/dev/input/hi")
 }
 
 #[test]
@@ -41,10 +41,10 @@ fn test_basic_modmap() {
               a: b
         "},
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_B, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_B, KeyValue::Release)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
@@ -98,7 +98,10 @@ fn test_relative_events() {
           - remap:
               XRIGHTCURSOR: b
         "},
-        vec![Event::RelativeEvent(get_input_device(), RelativeEvent::new_with(_REL_X, _POSITIVE))],
+        vec![Event::RelativeEvent(
+            get_input_device_info(),
+            RelativeEvent::new_with(_REL_X, _POSITIVE),
+        )],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
@@ -127,8 +130,8 @@ fn test_mouse_movement_event_accumulation() {
     assert_actions(
         indoc! {""},
         vec![
-            Event::RelativeEvent(get_input_device(), RelativeEvent::new_with(_REL_X, _POSITIVE)),
-            Event::RelativeEvent(get_input_device(), RelativeEvent::new_with(_REL_Y, _POSITIVE)),
+            Event::RelativeEvent(get_input_device_info(), RelativeEvent::new_with(_REL_X, _POSITIVE)),
+            Event::RelativeEvent(get_input_device_info(), RelativeEvent::new_with(_REL_Y, _POSITIVE)),
         ],
         vec![Action::MouseMovementEventCollection(vec![
             RelativeEvent::new_with(_REL_X, _POSITIVE),
@@ -256,8 +259,8 @@ fn test_interleave_modifiers() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -283,9 +286,9 @@ fn test_exact_match_true() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -305,9 +308,9 @@ fn test_exact_match_false() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -333,9 +336,9 @@ fn test_exact_match_default() {
               M-f: C-right
         "},
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_F, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
@@ -364,12 +367,12 @@ fn test_exact_match_true_nested() {
                   h: C-a
         "},
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -393,12 +396,12 @@ fn test_exact_match_false_nested() {
                   h: C-a
         "},
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -433,7 +436,10 @@ fn test_application_override() {
 
     assert_actions(
         config,
-        vec![Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_A, KeyValue::Press))],
+        vec![Event::KeyEvent(
+            get_input_device_info(),
+            KeyEvent::new(Key::KEY_A, KeyValue::Press),
+        )],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
@@ -447,7 +453,10 @@ fn test_application_override() {
     assert_actions_with_current_application(
         config,
         Some(String::from("firefox")),
-        vec![Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_A, KeyValue::Press))],
+        vec![Event::KeyEvent(
+            get_input_device_info(),
+            KeyEvent::new(Key::KEY_A, KeyValue::Press),
+        )],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Press)),
@@ -476,11 +485,11 @@ fn test_merge_remaps() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -498,11 +507,11 @@ fn test_merge_remaps() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_K, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_K, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -536,11 +545,11 @@ fn test_merge_remaps_with_override() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_H, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
@@ -558,11 +567,11 @@ fn test_merge_remaps_with_override() {
     assert_actions(
         config,
         vec![
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
-            Event::KeyEvent(get_input_device(), KeyEvent::new(Key::KEY_C, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_C, KeyValue::Press)),
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -29,7 +29,7 @@ impl Client for StaticClient {
 }
 
 fn get_input_device_info<'a>() -> InputDeviceInfo {
-    InputDeviceInfo::new("hi", "/dev/input/hi")
+    InputDeviceInfo::new("Some Device", "/dev/input/event0")
 }
 
 #[test]
@@ -455,6 +455,55 @@ fn test_application_override() {
         Some(String::from("firefox")),
         vec![Event::KeyEvent(
             get_input_device_info(),
+            KeyEvent::new(Key::KEY_A, KeyValue::Press),
+        )],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_device_override() {
+    let config = indoc! {"
+        keymap:
+
+          - name: event1
+            device:
+              only: [event1]
+            remap:
+              a: C-c
+
+          - name: event0
+            remap:
+              a: C-b
+    "};
+
+    assert_actions(
+        config,
+        vec![Event::KeyEvent(
+            InputDeviceInfo::new("Some Device", "/dev/input/event0"),
+            KeyEvent::new(Key::KEY_A, KeyValue::Press),
+        )],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    );
+
+    assert_actions(
+        config,
+        vec![Event::KeyEvent(
+            InputDeviceInfo::new("Some Device", "/dev/input/event1"),
             KeyEvent::new(Key::KEY_A, KeyValue::Press),
         )],
         vec![

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@ use evdev::InputEvent;
 use evdev::Key;
 use indoc::indoc;
 use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::client::{Client, WMClient};
@@ -34,7 +35,7 @@ fn get_input_device<'a> () -> InputDevice {
         Ok(input_devices) => input_devices,
         Err(e) => panic!("Failed to prepare input devices: {}", e),
     };
-    input_devices.values().next()
+    input_devices.remove(&PathBuf::from("/dev/input/event25")).unwrap()
 }
 
 #[test]


### PR DESCRIPTION
This patch adds support for `device.only` and `device.not`, akin to `application`, as suggested [here](https://github.com/k0kubun/xremap/issues/201#issuecomment-1414135214).

The matching logic from `--device` is reused, so devices may be specified by name, path, etc. For simplicity, regex matching is not implemented here. (I would not object to it being added later if desired.)