### PR TITLE
Added shared data field and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,33 @@ Some applications have trouble understanding synthesized key events, especially 
 Wayland. `keypress_delay_ms` can be used to workaround the issue.
 See [#179](https://github.com/k0kubun/xremap/issues/179) for the detail.
 
+### Shared data field
+
+You can declare data that does not directly go into the config under the `shared` field.  
+This can be usefull when using Anchors and Aliases.  
+For more information about the use of Yaml anchors see the [Yaml specification](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases).
+
+#### example:
+```yaml
+shared:
+  terminals: &terminals # The & Symbol marks this entry as a Anchor
+    - Gnome-terminal
+    - Kitty
+  
+  some_remaps: &some_remaps
+    Ctrl-f: C-right
+    Alt-b: C-up
+
+keymap:
+  applications:
+    only: *terminals # we can reuse the list here
+    not: *browsers
+  remap:
+    <<: *some_remaps # or we can reuse a map here. If there are duplicate keys, the key in the alias will be ignored.
+    Alt-f: C-right
+    Alt-b: C-left
+```
+
 ## License
 
 `xremap` is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,7 +17,7 @@ use evdev::Key;
 use keymap::Keymap;
 use modmap::Modmap;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de::IgnoredAny};
 use std::{collections::HashMap, error, fs, path::PathBuf, time::SystemTime};
 
 use self::{
@@ -39,6 +39,11 @@ pub struct Config {
     pub virtual_modifiers: Vec<Key>,
     #[serde(default)]
     pub keypress_delay_ms: u64,
+
+    // Data is not used by any part of the application.
+    // but can be used with Anchors and Aliases
+    #[serde(default)]
+    pub shared: IgnoredAny,
 
     // Internals
     #[serde(skip)]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -209,6 +209,46 @@ fn test_keymap_mark() {
     "})
 }
 
+#[test]
+fn test_shared_data_anchor() {
+    assert_parse(indoc! {"
+    shared:
+      terminals: &terminals
+        - Gnome-terminal
+        - Kitty
+
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        application:
+          not: *terminals
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: Google-chrome
+    "})
+}
+
+#[test]
+#[should_panic]
+fn test_fail_on_data_outside_of_config_model() {
+    assert_parse(indoc! {"
+    terminals: &terminals
+      - Gnome-terminal
+      - Kitty
+
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        application:
+          not: *terminals
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: Google-chrome
+    "})
+}
+
 fn assert_parse(yaml: &str) {
     let result: Result<Config, Error> = serde_yaml::from_str(yaml);
     if let Err(e) = result {


### PR DESCRIPTION
As discussed in #401 

I've added the `shared` field to the config struct for use with out of scope data.
This data can be used with Aliases and References.

The datatype is `ignoreAny` which is a way of discarding data in the deserializer.

Please let me know if any additions or changes are needed.