### PR TITLE
Add TOML support to xremap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.14",
 ]
 
 [[package]]
@@ -1270,6 +1270,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1530,10 +1539,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.3"
+name = "toml"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1542,6 +1566,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -1867,6 +1904,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "swayipc",
+ "toml 0.8.8",
  "wayland-client",
  "wayland-protocols-wlr",
  "x11rb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ wayland-protocols-wlr = { version = "0.1", features = ["client"], optional = tru
 x11rb = { version = "0.13.0", optional = true }
 zbus = { version = "1.9.2", optional = true }
 hyprland = { version = "0.3.12", optional = true }
+toml = "0.8.8"
 
 [features]
 gnome = ["zbus"]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -5,6 +5,253 @@ extern crate serde_yaml;
 extern crate toml;
 
 #[test]
+fn test_yaml_modmap_basic() {
+    yaml_assert_parse(indoc! {"
+    modmap:
+      - name: Global
+        remap:
+          Alt_L: Ctrl_L
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: Google-chrome
+    "})
+}
+
+#[test]
+fn test_yaml_modmap_application() {
+    yaml_assert_parse(indoc! {"
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        application:
+          not:
+            - Gnome-terminal
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: Google-chrome
+    "})
+}
+
+#[test]
+fn test_yaml_modmap_application_regex() {
+    yaml_assert_parse(indoc! {r"
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        application:
+          not:
+            - /^Minecraft/
+            - /^Minecraft\//
+            - /^Minecraft\d/
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: /^Miencraft\\/
+    "})
+}
+
+#[test]
+fn test_yaml_modmap_multi_purpose_key() {
+    yaml_assert_parse(indoc! {"
+    modmap:
+      - remap:
+          Space:
+            held: Shift_L
+            alone: Space
+      - remap:
+          Muhenkan:
+            held: Alt_L
+            alone: Muhenkan
+            alone_timeout_millis: 500
+    "})
+}
+#[test]
+fn test_yaml_modmap_multi_purpose_key_multi_key() {
+    yaml_assert_parse(indoc! {"
+    modmap:
+      - remap:
+          Space:
+            held: [Shift_L]
+            alone: [Shift_L,A]
+      - remap:
+          Muhenkan:
+            held: [Alt_L,Shift_L]
+            alone: [Muhenkan]
+            alone_timeout_millis: 500
+    "})
+}
+#[test]
+fn test_yaml_virtual_modifiers() {
+    yaml_assert_parse(indoc! {"
+    virtual_modifiers:
+      - CapsLock
+    "})
+}
+
+#[test]
+fn test_yaml_modmap_press_release_key() {
+    yaml_assert_parse(indoc! {r#"
+    modmap:
+      - remap:
+          Space:
+            press: { launch: ["wmctrl", "-x", "-a", "code.Code"] }
+            release: { launch: ["wmctrl", "-x", "-a", "nocturn.Nocturn"] }
+    "#})
+}
+
+#[test]
+fn test_yaml_keymap_basic() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - name: Global
+        remap:
+          Alt-Enter: Ctrl-Enter
+      - remap:
+          M-S: C-S
+    "})
+}
+
+#[test]
+fn test_yaml_keymap_lr_modifiers() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - name: Global
+        remap:
+          Alt_L-Enter: Ctrl_L-Enter
+      - remap:
+          M_R-S: C_L-S
+    "})
+}
+
+#[test]
+fn test_yaml_keymap_application() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - remap:
+          Alt-Enter: Ctrl-Enter
+        application:
+          not: Gnome-terminal
+      - remap:
+          Alt-S: Ctrl-S
+        application:
+          only:
+            - Gnome-terminal
+    "})
+}
+
+#[test]
+fn test_yaml_keymap_array() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - remap:
+          C-w:
+            - Shift-C-w
+            - C-x
+    "})
+}
+
+#[test]
+fn test_yaml_keymap_remap() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - remap:
+          C-x:
+            remap:
+              s: C-w
+              C-s:
+                remap:
+                  x: C-z
+            timeout_key: Down
+            timeout_millis: 1000
+    "})
+}
+
+#[test]
+fn test_yaml_keymap_launch() {
+    yaml_assert_parse(indoc! {r#"
+    keymap:
+      - remap:
+          KEY_GRAVE:
+            launch:
+              - "/bin/sh"
+              - "-c"
+              - "date > /tmp/hotkey_test"
+    "#})
+}
+
+#[test]
+fn test_yaml_keymap_mode() {
+    yaml_assert_parse(indoc! {"
+    default_mode: insert
+    keymap:
+      - mode: insert
+        remap:
+          Esc: { set_mode: normal }
+      - mode: normal
+        remap:
+          i: { set_mode: insert }
+          h: Left
+          j: Down
+          k: Up
+          l: Right
+    "})
+}
+
+#[test]
+fn test_yaml_keymap_mark() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - remap:
+          C-space: { set_mark: true }
+          C-g: [esc, { set_mark: false }]
+          C-b: { with_mark: left }
+          M-b: { with_mark: C-left }
+    "})
+}
+
+#[test]
+fn test_yaml_shared_data_anchor() {
+    yaml_assert_parse(indoc! {"
+    shared:
+      terminals: &terminals
+        - Gnome-terminal
+        - Kitty
+
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        application:
+          not: *terminals
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: Google-chrome
+    "})
+}
+
+#[test]
+#[should_panic]
+fn test_yaml_fail_on_data_outside_of_config_model() {
+    yaml_assert_parse(indoc! {"
+    terminals: &terminals
+      - Gnome-terminal
+      - Kitty
+
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        application:
+          not: *terminals
+      - remap:
+          Shift_R: Win_R
+        application:
+          only: Google-chrome
+    "})
+}
+
+#[test]
 fn test_toml_modmap_basic() {
     toml_assert_parse(indoc! {"
     [[modmap]]
@@ -276,252 +523,7 @@ fn test_toml_fail_on_data_outside_of_config_model() {
     "})
 }
 
-#[test]
-fn test_yaml_modmap_basic() {
-    yaml_assert_parse(indoc! {"
-    modmap:
-      - name: Global
-        remap:
-          Alt_L: Ctrl_L
-      - remap:
-          Shift_R: Win_R
-        application:
-          only: Google-chrome
-    "})
-}
 
-#[test]
-fn test_yaml_modmap_application() {
-    yaml_assert_parse(indoc! {"
-    modmap:
-      - remap:
-          Alt_L: Ctrl_L
-        application:
-          not:
-            - Gnome-terminal
-      - remap:
-          Shift_R: Win_R
-        application:
-          only: Google-chrome
-    "})
-}
-
-#[test]
-fn test_yaml_modmap_application_regex() {
-    yaml_assert_parse(indoc! {r"
-    modmap:
-      - remap:
-          Alt_L: Ctrl_L
-        application:
-          not:
-            - /^Minecraft/
-            - /^Minecraft\//
-            - /^Minecraft\d/
-      - remap:
-          Shift_R: Win_R
-        application:
-          only: /^Miencraft\\/
-    "})
-}
-
-#[test]
-fn test_yaml_modmap_multi_purpose_key() {
-    yaml_assert_parse(indoc! {"
-    modmap:
-      - remap:
-          Space:
-            held: Shift_L
-            alone: Space
-      - remap:
-          Muhenkan:
-            held: Alt_L
-            alone: Muhenkan
-            alone_timeout_millis: 500
-    "})
-}
-#[test]
-fn test_yaml_modmap_multi_purpose_key_multi_key() {
-    yaml_assert_parse(indoc! {"
-    modmap:
-      - remap:
-          Space:
-            held: [Shift_L]
-            alone: [Shift_L,A]
-      - remap:
-          Muhenkan:
-            held: [Alt_L,Shift_L]
-            alone: [Muhenkan]
-            alone_timeout_millis: 500
-    "})
-}
-#[test]
-fn test_yaml_virtual_modifiers() {
-    yaml_assert_parse(indoc! {"
-    virtual_modifiers:
-      - CapsLock
-    "})
-}
-
-#[test]
-fn test_yaml_modmap_press_release_key() {
-    yaml_assert_parse(indoc! {r#"
-    modmap:
-      - remap:
-          Space:
-            press: { launch: ["wmctrl", "-x", "-a", "code.Code"] }
-            release: { launch: ["wmctrl", "-x", "-a", "nocturn.Nocturn"] }
-    "#})
-}
-
-#[test]
-fn test_yaml_keymap_basic() {
-    yaml_assert_parse(indoc! {"
-    keymap:
-      - name: Global
-        remap:
-          Alt-Enter: Ctrl-Enter
-      - remap:
-          M-S: C-S
-    "})
-}
-
-#[test]
-fn test_yaml_keymap_lr_modifiers() {
-    yaml_assert_parse(indoc! {"
-    keymap:
-      - name: Global
-        remap:
-          Alt_L-Enter: Ctrl_L-Enter
-      - remap:
-          M_R-S: C_L-S
-    "})
-}
-
-#[test]
-fn test_yaml_keymap_application() {
-    yaml_assert_parse(indoc! {"
-    keymap:
-      - remap:
-          Alt-Enter: Ctrl-Enter
-        application:
-          not: Gnome-terminal
-      - remap:
-          Alt-S: Ctrl-S
-        application:
-          only:
-            - Gnome-terminal
-    "})
-}
-
-#[test]
-fn test_yaml_keymap_array() {
-    yaml_assert_parse(indoc! {"
-    keymap:
-      - remap:
-          C-w:
-            - Shift-C-w
-            - C-x
-    "})
-}
-
-#[test]
-fn test_yaml_keymap_remap() {
-    yaml_assert_parse(indoc! {"
-    keymap:
-      - remap:
-          C-x:
-            remap:
-              s: C-w
-              C-s:
-                remap:
-                  x: C-z
-            timeout_key: Down
-            timeout_millis: 1000
-    "})
-}
-
-#[test]
-fn test_yaml_keymap_launch() {
-    yaml_assert_parse(indoc! {r#"
-    keymap:
-      - remap:
-          KEY_GRAVE:
-            launch:
-              - "/bin/sh"
-              - "-c"
-              - "date > /tmp/hotkey_test"
-    "#})
-}
-
-#[test]
-fn test_yaml_keymap_mode() {
-    yaml_assert_parse(indoc! {"
-    default_mode: insert
-    keymap:
-      - mode: insert
-        remap:
-          Esc: { set_mode: normal }
-      - mode: normal
-        remap:
-          i: { set_mode: insert }
-          h: Left
-          j: Down
-          k: Up
-          l: Right
-    "})
-}
-
-#[test]
-fn test_yaml_keymap_mark() {
-    yaml_assert_parse(indoc! {"
-    keymap:
-      - remap:
-          C-space: { set_mark: true }
-          C-g: [esc, { set_mark: false }]
-          C-b: { with_mark: left }
-          M-b: { with_mark: C-left }
-    "})
-}
-
-#[test]
-fn test_yaml_shared_data_anchor() {
-    yaml_assert_parse(indoc! {"
-    shared:
-      terminals: &terminals
-        - Gnome-terminal
-        - Kitty
-
-    modmap:
-      - remap:
-          Alt_L: Ctrl_L
-        application:
-          not: *terminals
-      - remap:
-          Shift_R: Win_R
-        application:
-          only: Google-chrome
-    "})
-}
-
-#[test]
-#[should_panic]
-fn test_yaml_fail_on_data_outside_of_config_model() {
-    yaml_assert_parse(indoc! {"
-    terminals: &terminals
-      - Gnome-terminal
-      - Kitty
-
-    modmap:
-      - remap:
-          Alt_L: Ctrl_L
-        application:
-          not: *terminals
-      - remap:
-          Shift_R: Win_R
-        application:
-          only: Google-chrome
-    "})
-}
 
 fn toml_assert_parse(toml: &str) {
     let result: Result<Config, toml::de::Error> = toml::from_str(toml);
@@ -529,8 +531,6 @@ fn toml_assert_parse(toml: &str) {
         panic!("{}", e)
     }
 }
-
-
 
 fn yaml_assert_parse(yaml: &str) {
     let result: Result<Config, serde_yaml::Error> = serde_yaml::from_str(yaml);

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -523,8 +523,6 @@ fn test_toml_fail_on_data_outside_of_config_model() {
     "})
 }
 
-
-
 fn toml_assert_parse(toml: &str) {
     let result: Result<Config, toml::de::Error> = toml::from_str(toml);
     if let Err(e) = result {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,10 +1,284 @@
 use crate::Config;
 use indoc::indoc;
-use serde_yaml::Error;
+
+extern crate serde_yaml;
+extern crate toml;
 
 #[test]
-fn test_modmap_basic() {
-    assert_parse(indoc! {"
+fn test_toml_modmap_basic() {
+    toml_assert_parse(indoc! {"
+    [[modmap]]
+    name = \"Global\"
+    [modmap.remap]
+    Alt_L = \"Ctrl_L\"
+
+    [[modmap]]
+    [modmap.remap]
+    Shift_R = \"Win_R\"
+
+    [modmap.application]
+    only = \"Google-chrome\"
+    "})
+}
+
+#[test]
+fn test_toml_modmap_application() {
+    toml_assert_parse(indoc! {"
+    [[modmap]]
+    [modmap.remap]
+    Alt_L = \"Ctrl_L\"
+
+    [modmap.application]
+    not = [ \"Gnome-terminal\" ]
+
+    [[modmap]]
+    [modmap.remap]
+    Shift_R = \"Win_R\"
+
+    [modmap.application]
+    only = \"Google-chrome\"
+
+    "})
+}
+
+#[test]
+fn test_toml_modmap_application_regex() {
+    toml_assert_parse(indoc! {r#"
+    [[modmap]]
+    [modmap.remap]
+    Alt_L = "Ctrl_L"
+
+    [modmap.application]
+    not = [ "/^Minecraft/", "/^Minecraft\\//", "/^Minecraft\\d/" ]
+
+    [[modmap]]
+    [modmap.remap]
+    Shift_R = "Win_R"
+
+    [modmap.application]
+    only = "/^Miencraft\\\\/"
+
+    "#})
+}
+
+#[test]
+fn test_toml_modmap_multi_purpose_key() {
+    toml_assert_parse(indoc! {"
+    [[modmap]]
+    [modmap.remap.Space]
+    held = [ \"Shift_L\" ]
+    alone = \"Space\"
+
+    [[modmap]]
+    [modmap.remap.Muhenkan]
+    held = [ \"Alt_L\", \"Shift_L\" ]
+    alone = [ \"Muhenkan\" ]
+    alone_timeout_millis = 500
+    "})
+}
+
+#[test]
+fn test_toml_modmap_multi_purpose_key_multi_key() {
+    toml_assert_parse(indoc! {"
+    [[modmap]]
+    [modmap.remap.Space]
+    held = [ \"Shift_L\" ]
+    alone = [ \"Shift_L\", \"A\" ]
+
+    [[modmap]]
+    [modmap.remap.Muhenkan]
+    held = [ \"Alt_L\", \"Shift_L\" ]
+    alone = [ \"Muhenkan\" ]
+    alone_timeout_millis = 500
+    "})
+}
+#[test]
+fn test_toml_virtual_modifiers() {
+    toml_assert_parse(indoc! {"
+    virtual_modifiers = [ \"CapsLock\" ]
+    "})
+}
+
+#[test]
+fn test_toml_modmap_press_release_key() {
+    toml_assert_parse(indoc! {r#"
+    [[modmap]]
+    [modmap.remap.Space.press]
+    launch = [ "wmctrl", "-x", "-a", "code.Code" ]
+    [modmap.remap.Space.release]
+    launch = ["wmctrl", "-x", "-a", "nocturn.Nocturn"]
+    "#})
+}
+
+#[test]
+fn test_toml_keymap_basic() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    name = \"Global\"
+    [keymap.remap]
+    Alt-Enter = \"Ctrl-Enter\"
+
+    [[keymap]]
+    [keymap.remap]
+    M-S = \"C-S\"
+    "})
+}
+
+#[test]
+fn test_toml_keymap_lr_modifiers() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    name = \"Global\"
+    [keymap.remap]
+    Alt_L-Enter = \"Ctrl_L-Enter\"
+
+    [[keymap]]
+    [keymap.remap]
+    M_R-S = \"C_L-S\"
+    "})
+}
+
+#[test]
+fn test_toml_keymap_application() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    [keymap.remap]
+    Alt-Enter = \"Ctrl-Enter\"
+    [keymap.application]
+    not = \"Gnome-terminal\"
+    [[keymap]]
+    [keymap.remap]
+    Alt-S = \"Ctrl-S\"
+    [keymap.application]
+    only = \"Gnome-terminal\"
+    "})
+}
+
+#[test]
+fn test_toml_keymap_array() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    [keymap.remap]
+    C-w = [\"Shift-C-w\", \"C-x\"]
+    "})
+}
+
+#[test]
+fn test_toml_keymap_remap() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    [keymap.remap.C-x]
+    timeout_key = \"Down\"
+    timeout_millis = 1_000
+
+    [keymap.remap.C-x.remap]
+    s = \"C-w\"
+
+    [keymap.remap.C-x.remap.C-s.remap]
+    x = \"C-z\"
+    "})
+}
+
+#[test]
+fn test_toml_keymap_launch() {
+    toml_assert_parse(indoc! {r#"
+    [[keymap]]
+    [keymap.remap.KEY_GRAVE]
+    launch = [ "/bin/sh", "-c", "date > /tmp/hotkey_test" ]
+    "#})
+}
+
+#[test]
+fn test_toml_keymap_mode() {
+    toml_assert_parse(indoc! {"
+    default_mode = \"insert\"
+
+    [[keymap]]
+    mode = \"instert\"
+
+    [keymap.remap.Esc]
+    set_mode = \"normal\"
+
+    [[keymap]]
+    mode = \"normal\"
+
+    [keymap.remap]
+    h = \"Left\"
+    j = \"Down\"
+    k = \"Up\"
+    l = \"Right\"
+
+    [keymap.remap.i]
+    set_mode = \"insert\"
+
+    "})
+}
+
+#[test]
+fn test_toml_keymap_mark() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    [keymap.remap]
+    C-g = [ \"esc\", { set_mark = false } ]
+
+    [keymap.remap.C-space]
+    set_mark = true
+
+    [keymap.remap.C-b]
+    with_mark = \"left\"
+
+    [keymap.remap.M-b]
+    with_mark = \"C-left\"
+    "})
+}
+
+#[test]
+fn test_toml_shared_data_anchor() {
+    toml_assert_parse(indoc! {"
+    [shared]
+    terminals = [ \"Gnome-terminal\", \"Kitty\" ]
+
+    [[shared.modmap]]
+    [shared.modmap.remap]
+    Alt_L = \"Ctrl_L\"
+
+    [shared.modmap.application]
+    not = \"terminals\"
+
+    [[shared.modmap]]
+    [shared.modmap.remap]
+    Shift_R = \"Win_R\"
+
+    [shared.modmap.application]
+    only = \"Google-chrome\"
+    "})
+}
+
+#[test]
+#[should_panic]
+fn test_toml_fail_on_data_outside_of_config_model() {
+    toml_assert_parse(indoc! {"
+    terminals = [ \"Gnome-terminal\", \"Kitty\" ]
+
+    [[modmap]]
+    [modmap.remap]
+    Alt_L = \"Ctrl_L\"
+
+    [modmap.application]
+    not = [ \"Gnome-terminal\", \"Kitty\" ]
+
+    [[modmap]]
+    [modmap.remap]
+    Shift_R = \"Win_R\"
+
+    [modmap.application]
+    only = \"Google-chrome\"
+    "})
+}
+
+#[test]
+fn test_yaml_modmap_basic() {
+    yaml_assert_parse(indoc! {"
     modmap:
       - name: Global
         remap:
@@ -17,8 +291,8 @@ fn test_modmap_basic() {
 }
 
 #[test]
-fn test_modmap_application() {
-    assert_parse(indoc! {"
+fn test_yaml_modmap_application() {
+    yaml_assert_parse(indoc! {"
     modmap:
       - remap:
           Alt_L: Ctrl_L
@@ -33,8 +307,8 @@ fn test_modmap_application() {
 }
 
 #[test]
-fn test_modmap_application_regex() {
-    assert_parse(indoc! {r"
+fn test_yaml_modmap_application_regex() {
+    yaml_assert_parse(indoc! {r"
     modmap:
       - remap:
           Alt_L: Ctrl_L
@@ -51,8 +325,8 @@ fn test_modmap_application_regex() {
 }
 
 #[test]
-fn test_modmap_multi_purpose_key() {
-    assert_parse(indoc! {"
+fn test_yaml_modmap_multi_purpose_key() {
+    yaml_assert_parse(indoc! {"
     modmap:
       - remap:
           Space:
@@ -66,8 +340,8 @@ fn test_modmap_multi_purpose_key() {
     "})
 }
 #[test]
-fn test_modmap_multi_purpose_key_multi_key() {
-    assert_parse(indoc! {"
+fn test_yaml_modmap_multi_purpose_key_multi_key() {
+    yaml_assert_parse(indoc! {"
     modmap:
       - remap:
           Space:
@@ -81,16 +355,16 @@ fn test_modmap_multi_purpose_key_multi_key() {
     "})
 }
 #[test]
-fn test_virtual_modifiers() {
-    assert_parse(indoc! {"
+fn test_yaml_virtual_modifiers() {
+    yaml_assert_parse(indoc! {"
     virtual_modifiers:
       - CapsLock
     "})
 }
 
 #[test]
-fn test_modmap_press_release_key() {
-    assert_parse(indoc! {r#"
+fn test_yaml_modmap_press_release_key() {
+    yaml_assert_parse(indoc! {r#"
     modmap:
       - remap:
           Space:
@@ -100,8 +374,8 @@ fn test_modmap_press_release_key() {
 }
 
 #[test]
-fn test_keymap_basic() {
-    assert_parse(indoc! {"
+fn test_yaml_keymap_basic() {
+    yaml_assert_parse(indoc! {"
     keymap:
       - name: Global
         remap:
@@ -112,8 +386,8 @@ fn test_keymap_basic() {
 }
 
 #[test]
-fn test_keymap_lr_modifiers() {
-    assert_parse(indoc! {"
+fn test_yaml_keymap_lr_modifiers() {
+    yaml_assert_parse(indoc! {"
     keymap:
       - name: Global
         remap:
@@ -124,8 +398,8 @@ fn test_keymap_lr_modifiers() {
 }
 
 #[test]
-fn test_keymap_application() {
-    assert_parse(indoc! {"
+fn test_yaml_keymap_application() {
+    yaml_assert_parse(indoc! {"
     keymap:
       - remap:
           Alt-Enter: Ctrl-Enter
@@ -140,8 +414,8 @@ fn test_keymap_application() {
 }
 
 #[test]
-fn test_keymap_array() {
-    assert_parse(indoc! {"
+fn test_yaml_keymap_array() {
+    yaml_assert_parse(indoc! {"
     keymap:
       - remap:
           C-w:
@@ -151,8 +425,8 @@ fn test_keymap_array() {
 }
 
 #[test]
-fn test_keymap_remap() {
-    assert_parse(indoc! {"
+fn test_yaml_keymap_remap() {
+    yaml_assert_parse(indoc! {"
     keymap:
       - remap:
           C-x:
@@ -167,8 +441,8 @@ fn test_keymap_remap() {
 }
 
 #[test]
-fn test_keymap_launch() {
-    assert_parse(indoc! {r#"
+fn test_yaml_keymap_launch() {
+    yaml_assert_parse(indoc! {r#"
     keymap:
       - remap:
           KEY_GRAVE:
@@ -180,8 +454,8 @@ fn test_keymap_launch() {
 }
 
 #[test]
-fn test_keymap_mode() {
-    assert_parse(indoc! {"
+fn test_yaml_keymap_mode() {
+    yaml_assert_parse(indoc! {"
     default_mode: insert
     keymap:
       - mode: insert
@@ -198,8 +472,8 @@ fn test_keymap_mode() {
 }
 
 #[test]
-fn test_keymap_mark() {
-    assert_parse(indoc! {"
+fn test_yaml_keymap_mark() {
+    yaml_assert_parse(indoc! {"
     keymap:
       - remap:
           C-space: { set_mark: true }
@@ -210,8 +484,8 @@ fn test_keymap_mark() {
 }
 
 #[test]
-fn test_shared_data_anchor() {
-    assert_parse(indoc! {"
+fn test_yaml_shared_data_anchor() {
+    yaml_assert_parse(indoc! {"
     shared:
       terminals: &terminals
         - Gnome-terminal
@@ -231,8 +505,8 @@ fn test_shared_data_anchor() {
 
 #[test]
 #[should_panic]
-fn test_fail_on_data_outside_of_config_model() {
-    assert_parse(indoc! {"
+fn test_yaml_fail_on_data_outside_of_config_model() {
+    yaml_assert_parse(indoc! {"
     terminals: &terminals
       - Gnome-terminal
       - Kitty
@@ -249,8 +523,17 @@ fn test_fail_on_data_outside_of_config_model() {
     "})
 }
 
-fn assert_parse(yaml: &str) {
-    let result: Result<Config, Error> = serde_yaml::from_str(yaml);
+fn toml_assert_parse(toml: &str) {
+    let result: Result<Config, toml::de::Error> = toml::from_str(toml);
+    if let Err(e) = result {
+        panic!("{}", e)
+    }
+}
+
+
+
+fn yaml_assert_parse(yaml: &str) {
+    let result: Result<Config, serde_yaml::Error> = serde_yaml::from_str(yaml);
     if let Err(e) = result {
         panic!("{}", e)
     }


### PR DESCRIPTION
Apologies, forgot to commit my changes to Cargo.toml (and Cargo.lock). This is my second try, hopefully this passes :-)

I added TOML support in config::load_configs. First, it will check if the config file is valid YAML, then it will check for a valid TOML config file.

Tests are also updated accordingly.
