### PR TITLE
Don't emit unknown key, when mouse is moved

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -120,7 +120,10 @@ impl EventHandler {
         self.application_cache = None; // expire cache
         self.title_cache = None; // expire cache
         let key = Key::new(event.code());
-        debug!("=> {}: {:?}", event.value(), &key);
+        
+        if key.code() < DISGUISED_EVENT_OFFSETTER {
+            debug!("=> {}: {:?}", event.value(), &key);
+        }
 
         // Apply modmap
         let mut key_values = if let Some(key_action) = self.find_modmap(config, &key, device) {


### PR DESCRIPTION
`event_handler` emits all keys in debug mode: `RUST_LOG=debug`. But the synthetic keys from mouse movement are confusing, so I have filtered them out.