### PR TITLE
Add bridge for system service

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cargo install xremap --features wlroots # Sway, Wayfire, etc.
 cargo install xremap --features hypr    # Hyprland
 cargo install xremap --features niri    # Niri
 cargo install xremap --features cosmic  # COSMIC Wayland
-cargo install xremap --features socket  # Socket client with logind session monitor
+cargo install xremap --features socket  # Variant for system service
 cargo install xremap                    # Others
 ```
 

--- a/README.md
+++ b/README.md
@@ -673,6 +673,9 @@ Options:
 
           [possible values: true, false]
 
+      --bridge
+          Open a bridge from the desktop environment to the xremap system service. Since v0.15.1
+
       --completions <SHELL>
           Generate shell completions
 

--- a/doc/running_as_system_service.md
+++ b/doc/running_as_system_service.md
@@ -4,19 +4,17 @@ Ensure xremap is installed in `/usr/bin/xremap`, or use the right path below.
 
 Ensure module for creating output devices is loaded. See instructions elsewhere.
 
-Other things might be needed, because these instructions are fairly new.
-
 ### Pro
 
 - It's the most secure way to run `xremap`.
-- `xremap` is started automatically when your computer boots, and restarts if it fails.
+- `xremap` is started automatically when your computer boots, and restarts xremap if it fails.
 
 ### Con
 
 - A drawback is that the same config file is used for all users.
 - The config file is inconvenient to modify because it's owned by the xremap user.
-- If you launch programs from xremap they will run as the `xremap` user. Not your own normal user, except for GNOME desktop, see below.
-- If you want to use application-specific remappings it's only possible on GNOME, see below.
+- If you launch programs from xremap they will run as the `xremap` user. Not your own normal user. Except if you use the `socket` feature, see below.
+- If you want to use application-specific remappings it's only possible with the `socket` feature, see below.
 
 ## Create a system user named xremap
 
@@ -26,25 +24,6 @@ sudo useradd --no-create-home --shell /bin/false --user-group --groups input --s
 
 Note: The `xremap` user should only be used for this one purpose, to preserve security separation. Do not add your own user to the
 `xremap` group either for the same reason.
-
-## Best security: create xremap-{username} groups
-
-The "socket" feature variant of xremap monitors logind to select the socket path based on the active seated user session. The socket path (`/run/xremap/{uid}/xremap.sock` by default) will be created with permissions that restrict socket access to xremap and the `{uid}` user. Currently this only works with GNOME, although other desktop environments could and should make use of the same socket protocol.
-
-```sh
-# Add a xremap-{username} group for each user that will use xremap.
-# Replace {usernameN} with the username.
-sudo groupadd --system xremap-{username1}
-sudo groupadd --system xremap-{username2}
-sudo groupadd --system xremap-{username3}
-
-# Add each user to its respective xremap-{username} group
-sudo usermod --append --groups xremap-{username1} {username1}
-sudo usermod --append --groups xremap-{username2} {username2}
-sudo usermod --append --groups xremap-{username3} {username3}
-```
-
-Note: xremap will be enabled for all users, even those not having a `xremap-{username}` group, but application- and window-specific mappings will not function for users with no corresponding `xremap-{username}` group.
 
 ## Place your config file a central location
 
@@ -62,6 +41,24 @@ Change the ownership of the file:
 sudo chown xremap:xremap /etc/xremap/config.yml
 sudo chmod 644 /etc/xremap/config.yml
 ```
+
+## Create groups for socket feature (Optional)
+
+The `socket` variant of xremap lets you use application-specific remappings.
+
+```sh
+# Add a group for each user that will use xremap.
+sudo groupadd --system xremap-username1
+sudo groupadd --system xremap-username2
+
+# Add each user to its respective group
+sudo usermod --append --groups xremap-username1 username1
+sudo usermod --append --groups xremap-username2 username2
+```
+
+Note: You will have to restart for the new groups to take effect.
+
+Note: xremap will be enabled for all users, even those that don't have a `xremap-username` group, but application-specific remapping will only work for users with a corresponding `xremap-username` group.
 
 ## Create service file
 
@@ -83,11 +80,15 @@ SupplementaryGroups=input
 RuntimeDirectory=xremap
 RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
+Environment=RUST_LOG=warn # The default logging level
 
-# Add two lines for each xremap-{username} group created above, replacing
-# {username} and {uid} for each. Otherwise, comment or remove these lines.
-ExecStartPre=install --directory --mode 2770 --owner xremap --group xremap-{username} /run/xremap/{uid}
-SupplementaryGroups=xremap-{username}
+# Uncomment the following lines for the socket variant.
+# Remember to enter the right username and their corresponding uid.
+# To get the uid of the current user run "id" in the terminal, and `sudo -u username id` for other users.
+#ExecStartPre=install --directory --mode 2770 --owner xremap --group xremap-username1 /run/xremap/uid
+#SupplementaryGroups=xremap-username1
+#ExecStartPre=install --directory --mode 2770 --owner xremap --group xremap-username2 /run/xremap/uid
+#SupplementaryGroups=xremap-username2
 
 [Install]
 WantedBy=default.target
@@ -123,24 +124,51 @@ Run this command once:
 sudo systemctl enable xremap.service
 ```
 
-## Application-specific remappings
+## Application-specific remappings (socket feature)
+
+To use this feature you must choose the right variant of xremap for the system service. On the [Releases page](https://github.com/xremap/xremap/releases) choose a version with a name like `xremap-linux-x86_64-socket.zip`. This binary will connect to another instance of xremap, which runs as your normal user. Below are instructions for the second xremap instance:
 
 ### GNOME
 
-#### Create special service
-
 Ensure you are using xremap v0.14.10 or later.
 
-The GNOME extension is configured to use `/run/xremap/{uid}/xremap.sock` by default. The socket path can be changed with environment variables: set `XREMAP_SOCKET` in _xremap.service_, and for the GNOME extension, set `XREMAP_GNOME_SOCKET` in `~/.config/environment.d/99-xremap.conf` or `/etc/environment.d/90-xremap.conf`.
+The GNOME extension serves as the second instance of xremap.
 
 #### Install GNOME extension or login again
 
-Install GNOME extension version 12. If you already have this version installed you will need to login again.
+Install GNOME extension version 12, or later.
 
-Note: The service must be started at least once since system boot to create the folder `/run/xremap`. In
-case the GNOME extension is started before the service, you must login again for the GNOME
+In case the GNOME extension is started before the service, you must login again for the GNOME
 extension to work.
 
-### Other desktop environments
+The GNOME extension is configured to use `/run/xremap/{uid}/xremap.sock` by default. The socket path can be changed with environment variables: set `XREMAP_SOCKET` in _xremap.service_. For the GNOME extension, set `XREMAP_GNOME_SOCKET` in `~/.config/environment.d/99-xremap.conf` or `/etc/environment.d/90-xremap.conf`.
 
-Work in progress.
+### Other desktops than GNOME
+
+Ensure you are using xremap v0.15.1 or later.
+
+The second instance of xremap must match your desktop environment. So you can't avoid having two binaries. Start it by:
+
+```sh
+xremap --bridge
+```
+
+The only argument that `xremap` can take in bridge-mode is `xremap --bridge --no_window_logging`.
+
+You can run the bridge as a user service or autostart file, see this as inspiration [Running as a user service](running_as_user_service.md).
+
+The bridge only supports the default socket path: `/run/xremap/{uid}/xremap.sock`.
+
+### How the socket feature works
+
+When the `xremap.service` starts the `socket` variant of xremap it will function as the following:
+
+`xremap.service` creates a folder for the chosen users, e.g. `/run/xremap/1000`. This folder is only accessible
+to `xremap.service` and that user. When the user starts the GNOME extension or the bridge will the
+socket be created in the right folder, and `xremap.service` can connect to this socket.
+
+`xremap.service` monitors the active user to make sure
+it gets information from the right user, and launches commands as the right
+user (i.e. the user that controls the input devices).
+
+Note: The service must be started at least once since system boot to create the folders.

--- a/src/bridge/bridge_main.rs
+++ b/src/bridge/bridge_main.rs
@@ -1,0 +1,97 @@
+use crate::bridge::{Request, Response};
+use crate::client::{build_client, WMClient};
+use crate::command_runner::CommandRunner;
+use anyhow::{bail, Context};
+use nix::unistd::getuid;
+use std::fs::{exists, remove_file, set_permissions};
+use std::io::{prelude::*, BufReader};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+
+pub fn main(log_window_changes: bool, allow_launch: bool) -> anyhow::Result<()> {
+    let uid = getuid().as_raw();
+    let socket_path = format!("/run/xremap/{uid}/xremap.sock");
+    let mut command_runner = CommandRunner::new(allow_launch);
+    let mut wmclient = build_client(log_window_changes);
+
+    // This must be done to connect.
+    if !wmclient.client.supported() {
+        eprintln!("{} is not supported.", wmclient.name);
+        return Ok(());
+    }
+
+    let listener = get_listener(&socket_path)?;
+
+    for stream in listener.incoming() {
+        handle_connection(stream?, &mut wmclient, &mut command_runner)?
+    }
+
+    unreachable!()
+}
+
+fn get_listener(socket_path: &str) -> anyhow::Result<UnixListener> {
+    // Checks
+    let dir = Path::new(socket_path)
+        .parent()
+        .ok_or_else(|| anyhow::format_err!("The socket address must have a parent folder."))?;
+
+    if !exists(dir)? {
+        bail!("Parent folder of the socket address must exist: {dir:?}")
+    }
+
+    if exists(socket_path)? {
+        // TODO: Also clean up on shutdown. Even though it's not reliable.
+        remove_file(socket_path)?;
+    }
+
+    // Connect
+    let listener = UnixListener::bind(socket_path).context("Could not create socket")?;
+
+    set_permissions(socket_path, std::fs::Permissions::from_mode(0o660))
+        .context(format!("Can't set permission for socket: {socket_path}"))?;
+
+    Ok(listener)
+}
+
+fn handle_connection(
+    stream: UnixStream,
+    wmclient: &mut WMClient,
+    command_runner: &mut CommandRunner,
+) -> anyhow::Result<()> {
+    // Request
+    let mut reader = BufReader::new(stream);
+    let mut request = String::new();
+    reader.read_line(&mut request)?;
+
+    let request = serde_json::from_str::<Request>(&request)?;
+    let response =
+        handle_request(request, wmclient, command_runner).unwrap_or_else(|err| Response::Error(err.to_string()));
+
+    // Response
+    reader
+        .into_inner()
+        .write_all(serde_json::to_string(&response)?.as_bytes())?;
+
+    Ok(())
+}
+
+fn handle_request(
+    request: Request,
+    wmclient: &mut WMClient,
+    command_runner: &mut CommandRunner,
+) -> anyhow::Result<Response> {
+    match request {
+        Request::ActiveWindow => Ok(Response::ActiveWindow {
+            title: wmclient.current_window().unwrap_or_default(),
+            wm_class: wmclient.current_application().unwrap_or_default(),
+        }),
+
+        Request::WindowList => Ok(Response::WindowList(wmclient.window_list()?)),
+
+        Request::Run(command) => {
+            command_runner.run(command);
+            Ok(Response::Ok)
+        }
+    }
+}

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -1,0 +1,8 @@
+mod bridge_main;
+mod types;
+
+pub use bridge_main::main;
+#[cfg(any(feature = "gnome", feature = "socket"))]
+pub use types::ActiveWindow;
+pub use types::Request;
+pub use types::Response;

--- a/src/bridge/types.rs
+++ b/src/bridge/types.rs
@@ -1,0 +1,58 @@
+use crate::client::WindowInfo;
+use serde::{Deserialize, Serialize};
+
+// Used by gnome extension. But not the bridge.
+#[cfg(any(test, feature = "gnome", feature = "socket"))]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct ActiveWindow {
+    #[serde(default)]
+    pub wm_class: String,
+    #[serde(default)]
+    pub title: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum Request {
+    ActiveWindow,
+    Run(Vec<String>),
+    WindowList,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum Response {
+    Ok,
+    Error(String),
+    ActiveWindow { title: String, wm_class: String },
+    WindowList(Vec<WindowInfo>),
+}
+
+#[test]
+fn test_bridge_request() {
+    assert_eq!(Request::ActiveWindow, serde_json::from_str::<Request>("\"ActiveWindow\"").unwrap());
+    assert_eq!(Request::Run(vec!["foo".into()]), serde_json::from_str::<Request>("{\"Run\": [\"foo\"]}").unwrap());
+    assert_eq!(Request::WindowList, serde_json::from_str::<Request>("\"WindowList\"").unwrap());
+}
+
+#[test]
+fn test_bridge_response() {
+    assert_eq!(Response::Ok, serde_json::from_str::<Response>("\"Ok\"").unwrap());
+    assert_eq!(
+        Response::ActiveWindow {
+            title: "foo".into(),
+            wm_class: "bar".into()
+        },
+        serde_json::from_str::<Response>("{\"ActiveWindow\":{\"title\":\"foo\",\"wm_class\":\"bar\"}}\n").unwrap()
+    );
+}
+
+#[test]
+fn test_legacy_bridge_response() {
+    // Used by gnome extension
+    assert_eq!(
+        ActiveWindow {
+            title: "foo".into(),
+            wm_class: "bar".into()
+        },
+        serde_json::from_str::<ActiveWindow>("{\"title\":\"foo\",\"wm_class\":\"bar\"}\n").unwrap()
+    );
+}

--- a/src/client/gnome_client.rs
+++ b/src/client/gnome_client.rs
@@ -1,8 +1,8 @@
+use crate::bridge::ActiveWindow;
 use crate::client::{Client, WindowInfo};
 use anyhow::bail;
 use futures::executor::block_on;
 use log::debug;
-use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
@@ -166,12 +166,4 @@ impl Client for GnomeClient {
     fn window_list(&mut self) -> anyhow::Result<Vec<WindowInfo>> {
         bail!("window_list not implemented for GNOME")
     }
-}
-
-#[derive(Serialize, Deserialize)]
-struct ActiveWindow {
-    #[serde(default)]
-    wm_class: String,
-    #[serde(default)]
-    title: String,
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,5 @@
 use crate::util::print_table;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "cosmic")]
 mod cosmic_client;
@@ -23,7 +24,7 @@ mod x11_client;
 
 mod null_client;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct WindowInfo {
     // The order of fields matters because they define sort order.
     pub app_class: Option<String>,
@@ -46,8 +47,8 @@ pub trait Client {
 }
 
 pub struct WMClient {
-    name: String,
-    client: Box<dyn Client>,
+    pub name: String,
+    pub client: Box<dyn Client>,
     supported: Option<bool>,
     last_application: String,
     last_window: String,

--- a/src/client/socket_client.rs
+++ b/src/client/socket_client.rs
@@ -2,7 +2,7 @@ use super::socket_monitor::SessionMonitor;
 use crate::bridge::ActiveWindow;
 use crate::bridge::{Request, Response};
 use crate::client::{Client, WindowInfo};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use log::debug;
 use regex::Regex;
 use std::io::{BufRead, BufReader, Write};
@@ -86,7 +86,8 @@ impl SocketClient {
 
     fn call_via_socket<T: serde::Serialize>(&self, command: T) -> Result<String> {
         let session = self.monitor.get_active_session().ok_or(anyhow!("no active session"))?;
-        let mut stream = UnixStream::connect(session.user_socket)?;
+        let mut stream = UnixStream::connect(&session.user_socket)
+            .context(format!("Could not connect to socket: {:?}", session.user_socket))?;
         stream.set_write_timeout(Some(Duration::from_millis(500)))?;
         stream.set_read_timeout(Some(Duration::from_millis(500)))?;
         stream.write_all(serde_json::to_string(&command)?.as_bytes())?;

--- a/src/client/socket_client.rs
+++ b/src/client/socket_client.rs
@@ -59,7 +59,7 @@ impl SocketClient {
             Ok(response) => match response {
                 Response::ActiveWindow { title, wm_class } => Ok(ActiveWindow { title, wm_class }),
                 Response::Error(message) => bail!(message),
-                _ => unreachable!(),
+                response => bail!("Wrong response from client {response:?}"),
             },
             Err(_) => {
                 // Fallback to gnome extension
@@ -71,7 +71,7 @@ impl SocketClient {
     fn command(&self, request: Request) -> Result<()> {
         match self.request_typed(request)? {
             Response::Ok => Ok(()),
-            _ => unreachable!(),
+            response => bail!("Wrong response from client {response:?}"),
         }
     }
 
@@ -137,7 +137,7 @@ impl Client for SocketClient {
     fn window_list(&mut self) -> anyhow::Result<Vec<WindowInfo>> {
         match self.request_typed(Request::WindowList)? {
             Response::WindowList(window_list) => Ok(window_list),
-            _ => unreachable!(),
+            response => bail!("Wrong response from client {response:?}"),
         }
     }
 }

--- a/src/client/socket_client.rs
+++ b/src/client/socket_client.rs
@@ -55,7 +55,17 @@ impl SocketClient {
 
     fn get_active_window(&self) -> Result<ActiveWindow> {
         let json = self.call_via_socket("ActiveWindow")?;
-        Ok(serde_json::from_str::<ActiveWindow>(&json)?)
+        match serde_json::from_str::<Response>(&json) {
+            Ok(response) => match response {
+                Response::ActiveWindow { title, wm_class } => Ok(ActiveWindow { title, wm_class }),
+                Response::Error(message) => bail!(message),
+                _ => unreachable!(),
+            },
+            Err(_) => {
+                // Fallback to gnome extension
+                Ok(serde_json::from_str::<ActiveWindow>(&json)?)
+            }
+        }
     }
 
     fn request_typed(&self, request: Request) -> Result<Response> {

--- a/src/client/socket_client.rs
+++ b/src/client/socket_client.rs
@@ -1,9 +1,10 @@
 use super::socket_monitor::SessionMonitor;
+use crate::bridge::ActiveWindow;
+use crate::bridge::{Request, Response};
 use crate::client::{Client, WindowInfo};
 use anyhow::{anyhow, bail, Result};
 use log::debug;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
@@ -55,6 +56,15 @@ impl SocketClient {
     fn get_active_window(&self) -> Result<ActiveWindow> {
         let json = self.call_via_socket("ActiveWindow")?;
         Ok(serde_json::from_str::<ActiveWindow>(&json)?)
+    }
+
+    fn request_typed(&self, request: Request) -> Result<Response> {
+        let response = self.call_via_socket(request)?;
+        match serde_json::from_str::<Response>(&response)? {
+            // Filter errors to make further processing easier.
+            Response::Error(message) => bail!(message),
+            response => Ok(response),
+        }
     }
 
     fn call_via_socket<T: serde::Serialize>(&self, command: T) -> Result<String> {
@@ -112,14 +122,9 @@ impl Client for SocketClient {
     }
 
     fn window_list(&mut self) -> anyhow::Result<Vec<WindowInfo>> {
-        bail!("window_list not implemented for socket")
+        match self.request_typed(Request::WindowList)? {
+            Response::WindowList(window_list) => Ok(window_list),
+            _ => unreachable!(),
+        }
     }
-}
-
-#[derive(Serialize, Deserialize)]
-struct ActiveWindow {
-    #[serde(default)]
-    wm_class: String,
-    #[serde(default)]
-    title: String,
 }

--- a/src/client/socket_client.rs
+++ b/src/client/socket_client.rs
@@ -68,6 +68,13 @@ impl SocketClient {
         }
     }
 
+    fn command(&self, request: Request) -> Result<()> {
+        match self.request_typed(request)? {
+            Response::Ok => Ok(()),
+            _ => unreachable!(),
+        }
+    }
+
     fn request_typed(&self, request: Request) -> Result<Response> {
         let response = self.call_via_socket(request)?;
         match serde_json::from_str::<Response>(&response)? {
@@ -122,13 +129,8 @@ impl Client for SocketClient {
     }
 
     fn run(&mut self, command: &Vec<String>) -> anyhow::Result<bool> {
-        let request = serde_json::json!({"Run": command});
-        let response = self.call_via_socket(&request)?;
-        let parsed = serde_json::from_str::<serde_json::Value>(&response);
-        match parsed {
-            Ok(v) if v == "Ok" => Ok(true),
-            _ => Err(anyhow::format_err!(response)),
-        }
+        self.command(Request::Run(command.clone()))?;
+        Ok(true)
     }
 
     fn window_list(&mut self) -> anyhow::Result<Vec<WindowInfo>> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -161,7 +161,7 @@ fn test_yaml_modmap_any_key_is_not_valid() {
 }
 
 #[test]
-fn test_yaml_keymap_can_not_emit_relative_events_cur() {
+fn test_yaml_keymap_can_not_emit_relative_events() {
     assert_invalid_config(
         indoc! {"
         keymap:

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use std::time::Duration;
 
 mod action;
 mod action_dispatcher;
+mod bridge;
 mod client;
 mod command_runner;
 mod config;
@@ -116,6 +117,7 @@ struct Args {
         required_unless_present = "list_devices",
         required_unless_present = "device_details",
         required_unless_present = "list_windows",
+        required_unless_present = "bridge",
         num_args = 1..)]
     configs: Vec<PathBuf>,
     /// Choose the vendor value of the created output device.
@@ -143,6 +145,9 @@ struct Args {
     /// Allow remappings to execute programs. Default is ambiguous. Since v0.15.1
     #[arg(long)]
     allow_launch: Option<bool>,
+    /// Open a bridge from the desktop environment to the xremap system service. Since v0.15.1
+    #[arg(long)]
+    bridge: bool,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -171,6 +176,7 @@ fn main() -> anyhow::Result<()> {
         list_windows,
         no_window_logging,
         allow_launch,
+        bridge,
     } = Args::parse();
 
     if let Some(shell) = completions {
@@ -190,6 +196,11 @@ fn main() -> anyhow::Result<()> {
 
     if list_windows {
         return print_open_windows();
+    }
+
+    if bridge {
+        // Default deny launch
+        return bridge::main(!no_window_logging, allow_launch.unwrap_or(false));
     }
 
     if let Some(output_device_name) = output_device_name {


### PR DESCRIPTION
When xremap runs as a system service, there is no reasonable way for it to communicate with the desktop environment, or launch commands as the normal user.

This PR adds a command line option `--bridge`, which doesn't open input devices and do remapping, but instead creates a socket, that the system service can use to get information and launch commands.

The socket feature has already been implemented, and has been working for GNOME since this PR #805