### PR TITLE
Debounce option for config watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ keymap:
 
 See also: [example/config.yml](example/config.yml) and [example/emacs.yml](example/emacs.yml)
 
+The configuration file has 3 parts. `modmap`, `keymap` and [Configuration options](doc/reference_config_options.md). `modmap` and `keymap` are described below.
+
 ### modmap
 
 `modmap` is for key-to-key remapping like xmodmap.
@@ -541,69 +543,6 @@ keymap:
     mode: [Up, Down, Right_And_Left, Up_And_Down, Off] # You can assign modes to keymap too!
 
 default_mode: Up_And_Down # Optional, if absent default mode is "default"
-```
-
-### virtual_modifiers
-
-You can declare keys that should act like a modifier.
-
-```yml
-virtual_modifiers:
-  - CapsLock
-keymap:
-  - remap:
-      CapsLock-i: Up
-      CapsLock-j: Left
-      CapsLock-k: Down
-      CapsLock-l: Right
-```
-
-### keypress_delay_ms
-
-Default is `0ms`.
-
-Some applications have trouble understanding synthesized key events, especially on
-Wayland. `keypress_delay_ms` can be used to workaround the issue. Only events from
-key combos in `keymap` are delayed. If that isn't enough try `throttle_ms`.
-
-### throttle_ms
-
-Default is `0ms`.
-
-Slow down synthetic events, so applications have the time to register events.
-All events from anywhere in xremap are slowed down between:
-
-- Press and release of the same key. But not the other way around.
-- Press of ordinary key and press/release of modifier key.
-- Press/release of modifier key and press of ordinary key.
-
-The delay is only added if needed. That is there's no delay if the time has already elapsed.
-
-The logic is choosen to allow applications enough time to register the exact modifiers pressed when
-a key is pressed, and keep to key pressed enough time.
-
-### Shared data field
-
-You can declare data that does not directly go into the config under the `shared` field.  
-This can be usefull when using Anchors and Aliases.  
-For more information about the use of Yaml anchors see the [Yaml specification](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases).
-
-#### example:
-
-```yaml
-shared:
-  terminals: &terminals # The & Symbol marks this entry as a Anchor
-    - Gnome-terminal
-    - Kitty
-
-  some_remaps: &some_remaps
-    Ctrl-f: C-right
-    Alt-b: C-up
-
-keymap:
-  - application:
-      only: *terminals # we can reuse the list here
-    remap: *some_remaps # and we can reuse a map here.
 ```
 
 ## Commandline arguments

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,6 +15,7 @@ You can choose between the following ways to run xremap. They are ordered by the
 
 ### Configuration file reference
 
+- [Configuration options](reference_config_options.md)
 - [Multi-purpose key (alias: tap-hold key)](reference_multipurpose_key.md)
 
 ### Experimental features

--- a/doc/reference_config_options.md
+++ b/doc/reference_config_options.md
@@ -39,6 +39,22 @@ The delay is only added if needed. That is there's no delay if the time has alre
 The logic is choosen to allow applications enough time to register the exact modifiers pressed when
 a key is pressed, and keep to key pressed enough time.
 
+### config_watch_debounce_ms
+
+```yml
+config_watch_debounce_ms: 20 # Default is '0'
+# Rest of your config file
+```
+
+When using `--watch=config` to watch configuration files for changes, a delay can be needed to ignore
+some of the file-change events. This can help an error where the old configuration is unloaded
+when a configuration file with errors is saved.
+
+By waiting for the inactivity to have remained e.g. `20ms` will only that final event
+be used and therefore are all the 'wrong' events just ignored.
+
+Since version 0.15.1.
+
 ### Shared data field
 
 You can declare data that does not directly go into the config under the `shared` field.  

--- a/doc/reference_config_options.md
+++ b/doc/reference_config_options.md
@@ -1,0 +1,64 @@
+## Configuration options
+
+### virtual_modifiers
+
+You can declare keys that should act like a modifier.
+
+```yml
+virtual_modifiers:
+  - CapsLock
+keymap:
+  - remap:
+      CapsLock-i: Up
+      CapsLock-j: Left
+      CapsLock-k: Down
+      CapsLock-l: Right
+```
+
+### keypress_delay_ms
+
+Default is `0ms`.
+
+Some applications have trouble understanding synthesized key events, especially on
+Wayland. `keypress_delay_ms` can be used to workaround the issue. Only events from
+key combos in `keymap` are delayed. If that isn't enough try `throttle_ms`.
+
+### throttle_ms
+
+Default is `0ms`.
+
+Slow down synthetic events, so applications have the time to register events.
+All events from anywhere in xremap are slowed down between:
+
+- Press and release of the same key. But not the other way around.
+- Press of ordinary key and press/release of modifier key.
+- Press/release of modifier key and press of ordinary key.
+
+The delay is only added if needed. That is there's no delay if the time has already elapsed.
+
+The logic is choosen to allow applications enough time to register the exact modifiers pressed when
+a key is pressed, and keep to key pressed enough time.
+
+### Shared data field
+
+You can declare data that does not directly go into the config under the `shared` field.  
+This can be usefull when using Anchors and Aliases.  
+For more information about the use of Yaml anchors see the [Yaml specification](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases).
+
+#### example:
+
+```yaml
+shared:
+  terminals: &terminals # The & Symbol marks this entry as a Anchor
+    - Gnome-terminal
+    - Kitty
+
+  some_remaps: &some_remaps
+    Ctrl-f: C-right
+    Alt-b: C-up
+
+keymap:
+  - application:
+      only: *terminals # we can reuse the list here
+    remap: *some_remaps # and we can reuse a map here.
+```

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -52,6 +52,8 @@ pub struct Config {
     pub keypress_delay_ms: u64,
     #[serde(default)]
     pub throttle_ms: u64,
+    #[serde(default)]
+    pub config_watch_debounce_ms: u64,
 
     // Data is not used by any part of the application.
     // but can be used with Anchors and Aliases

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,6 +13,7 @@ pub mod nested_remap;
 #[cfg(test)]
 mod tests;
 mod validation;
+mod watcher;
 
 extern crate serde_yaml;
 extern crate toml;
@@ -25,13 +26,13 @@ use crate::event_handler::MODIFIER_KEYS;
 use evdev::KeyCode as Key;
 use keymap::Keymap;
 use modmap::Modmap;
-use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use serde::{de::IgnoredAny, Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use std::{error, fs};
 pub use validation::validate_config_file;
+pub use watcher::ConfigWatcher;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -117,22 +118,6 @@ pub fn load_configs(filenames: &[PathBuf]) -> Result<Config, Box<dyn error::Erro
     validate_config_file(&config)?;
 
     Ok(config)
-}
-
-pub fn config_watcher(watch: bool, files: &Vec<PathBuf>) -> anyhow::Result<Option<Inotify>> {
-    if watch {
-        let inotify = Inotify::init(InitFlags::IN_NONBLOCK)?;
-        for file in files {
-            inotify.add_watch(
-                file.parent().expect("config file has a parent directory"),
-                AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO,
-            )?;
-            inotify.add_watch(file, AddWatchFlags::IN_MODIFY)?;
-        }
-        Ok(Some(inotify))
-    } else {
-        Ok(None)
-    }
 }
 
 fn default_mode() -> String {

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -1,0 +1,111 @@
+use crate::config::{load_configs, Config};
+use anyhow::Result;
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, InotifyEvent};
+use nix::sys::select::FdSet;
+use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct ConfigWatcher {
+    files: Vec<PathBuf>,
+    debounce_events: bool,
+    timer_fd: RawFd,
+    #[allow(warnings)]
+    timer: TimerFd,
+    inotify: Inotify,
+}
+
+impl ConfigWatcher {
+    pub fn new(watch: bool, files: Vec<PathBuf>) -> Result<(Option<RawFd>, Option<Inotify>, Option<Self>)> {
+        if !watch {
+            return Ok((None, None, None));
+        }
+
+        let inotify = Inotify::init(InitFlags::IN_NONBLOCK)?;
+        for file in &files {
+            inotify.add_watch(
+                file.parent().expect("config file has a parent directory"),
+                AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO,
+            )?;
+            inotify.add_watch(file, AddWatchFlags::IN_MODIFY)?;
+        }
+
+        let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
+
+        let this = Self {
+            files,
+            debounce_events: false,
+            timer_fd: timer.as_raw_fd(),
+            timer,
+            inotify,
+        };
+
+        Ok((Some(this.timer_fd), Some(this.inotify), Some(this)))
+    }
+
+    pub fn handle(&mut self, readable_fds: FdSet) -> Result<Option<Config>> {
+        if readable_fds.contains(self.timer_fd) {
+            todo!()
+        }
+
+        if let Ok(events) = self.inotify.read_events() {
+            if self.config_changed(events)? {
+                if self.debounce_events {
+                    todo!()
+                } else {
+                    return Ok(Some(self.get_config()?));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn get_config(&mut self) -> Result<Config> {
+        let result = load_configs(&self.files);
+        match &result {
+            Ok(_) => {
+                println!("Reloading Config");
+            }
+            Err(_) => {}
+        }
+
+        result.map_err(|err| anyhow::format_err!("{err}"))
+    }
+
+    fn config_changed(&self, events: Vec<InotifyEvent>) -> Result<bool> {
+        //Re-add AddWatchFlags if config file has been deleted then recreated or overwritten by renaming another file to its own name
+        for event in &events {
+            if event
+                .mask
+                .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
+            {
+                for config_path in &self.files {
+                    if config_path.file_name().unwrap_or_default() == event.name.clone().unwrap_or_default() {
+                        self.inotify.add_watch(config_path, AddWatchFlags::IN_MODIFY)?;
+                    }
+                }
+            }
+        }
+        for event in &events {
+            match (event.mask, &event.name) {
+                // Dir events
+                (_, Some(name))
+                    if self
+                        .files
+                        .iter()
+                        .any(|p| name == p.file_name().expect("Config path has a file name")) =>
+                {
+                    return Ok(true)
+                }
+                // File events
+                (mask, _) if mask.contains(AddWatchFlags::IN_MODIFY) => return Ok(true),
+                // Unrelated
+                _ => (),
+            }
+        }
+
+        Ok(false)
+    }
+}

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -2,22 +2,28 @@ use crate::config::{load_configs, Config};
 use anyhow::Result;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, InotifyEvent};
 use nix::sys::select::FdSet;
-use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
+use nix::sys::time::TimeSpec;
+use nix::sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
+use std::time::Duration;
 
 #[derive(Debug)]
 pub struct ConfigWatcher {
     files: Vec<PathBuf>,
-    debounce_events: bool,
+    debounce: Option<Duration>,
     timer_fd: RawFd,
-    #[allow(warnings)]
     timer: TimerFd,
     inotify: Inotify,
+    change_pending: bool,
 }
 
 impl ConfigWatcher {
-    pub fn new(watch: bool, files: Vec<PathBuf>) -> Result<(Option<RawFd>, Option<Inotify>, Option<Self>)> {
+    pub fn new(
+        watch: bool,
+        files: Vec<PathBuf>,
+        debounce_ms: u64,
+    ) -> Result<(Option<RawFd>, Option<Inotify>, Option<Self>)> {
         if !watch {
             return Ok((None, None, None));
         }
@@ -33,12 +39,19 @@ impl ConfigWatcher {
 
         let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
 
+        let debounce = if debounce_ms == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(debounce_ms))
+        };
+
         let this = Self {
             files,
-            debounce_events: false,
+            debounce,
             timer_fd: timer.as_raw_fd(),
             timer,
             inotify,
+            change_pending: false,
         };
 
         Ok((Some(this.timer_fd), Some(this.inotify), Some(this)))
@@ -46,16 +59,22 @@ impl ConfigWatcher {
 
     pub fn handle(&mut self, readable_fds: FdSet) -> Result<Option<Config>> {
         if readable_fds.contains(self.timer_fd) {
-            todo!()
+            return Ok(Some(self.get_config()?));
         }
 
         if let Ok(events) = self.inotify.read_events() {
             if self.config_changed(events)? {
-                if self.debounce_events {
-                    todo!()
-                } else {
-                    return Ok(Some(self.get_config()?));
-                }
+                match self.debounce {
+                    Some(debounce) => {
+                        // Could already be set, but reset is the debounce.
+                        self.change_pending = true;
+                        self.timer
+                            .set(Expiration::OneShot(TimeSpec::from_duration(debounce)), TimerSetTimeFlags::empty())?;
+                    }
+                    None => {
+                        return Ok(Some(self.get_config()?));
+                    }
+                };
             }
         }
 
@@ -63,6 +82,8 @@ impl ConfigWatcher {
     }
 
     fn get_config(&mut self) -> Result<Config> {
+        self.change_pending = false;
+        self.timer.unset()?;
         let result = load_configs(&self.files);
         match &result {
             Ok(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,12 +337,16 @@ fn main() -> anyhow::Result<()> {
             if let Some(inotify) = config_watcher {
                 if let Ok(events) = inotify.read_events() {
                     if !handle_config_changes(events, &config_paths, inotify)? {
-                        if let Ok(c) = load_configs(&config_paths) {
+                        match load_configs(&config_paths) {
+                            Ok(c) => {
                             println!("Reloading Config");
                             config = c;
+                                continue 'event_loop;
+                            }
+                            Err(_) => {
+                                continue 'event_loop;
                         }
-
-                        continue 'event_loop;
+                        };
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ fn main() -> anyhow::Result<()> {
     };
     let device_watcher = device_watcher(watch_devices).context("Setting up device watcher")?;
     let (config_watcher_fd, config_watcher_inotify, mut config_watcher) =
-        ConfigWatcher::new(watch_config, config_paths)?;
+        ConfigWatcher::new(watch_config, config_paths, config.config_watch_debounce_ms)?;
     let watchers: Vec<_> = device_watcher.iter().chain(config_watcher_inotify.iter()).collect();
 
     // wmclient

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use crate::client::print_open_windows;
-use crate::config::Config;
+use crate::config::{Config, ConfigWatcher};
 use crate::device::{
     device_watcher, get_input_devices, output_device, print_device_details, print_device_list, DEVICE_NAME,
 };
@@ -13,11 +13,10 @@ use action_dispatcher::ActionDispatcher;
 use anyhow::{anyhow, bail, Context};
 use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::Shell;
-use config::{config_watcher, load_configs};
 use device::InputDevice;
 use event::Event;
 use nix::libc::ENODEV;
-use nix::sys::inotify::{AddWatchFlags, Inotify, InotifyEvent};
+use nix::sys::inotify::{Inotify, InotifyEvent};
 use nix::sys::select::select;
 use nix::sys::select::FdSet;
 use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
@@ -237,8 +236,9 @@ fn main() -> anyhow::Result<()> {
         Err(e) => bail!("Failed to prepare input devices: {}", e),
     };
     let device_watcher = device_watcher(watch_devices).context("Setting up device watcher")?;
-    let config_watcher = config_watcher(watch_config, &config_paths).context("Setting up config watcher")?;
-    let watchers: Vec<_> = device_watcher.iter().chain(config_watcher.iter()).collect();
+    let (config_watcher_fd, config_watcher_inotify, mut config_watcher) =
+        ConfigWatcher::new(watch_config, config_paths)?;
+    let watchers: Vec<_> = device_watcher.iter().chain(config_watcher_inotify.iter()).collect();
 
     // wmclient
     // Default allow launch (Change to false in a major upgrade)
@@ -271,7 +271,8 @@ fn main() -> anyhow::Result<()> {
     // Main loop
     loop {
         'event_loop: loop {
-            let readable_fds = select_readable(input_devices.values(), &watchers, timer_fd, timeout_manager_fd)?;
+            let readable_fds =
+                select_readable(input_devices.values(), &watchers, timer_fd, timeout_manager_fd, config_watcher_fd)?;
             if readable_fds.contains(timer_fd) {
                 if let Err(error) = handle_events(
                     &mut handler,
@@ -334,21 +335,16 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
-            if let Some(inotify) = config_watcher {
-                if let Ok(events) = inotify.read_events() {
-                    if !handle_config_changes(events, &config_paths, inotify)? {
-                        match load_configs(&config_paths) {
-                            Ok(c) => {
-                            println!("Reloading Config");
-                            config = c;
-                                continue 'event_loop;
-                            }
-                            Err(_) => {
-                                continue 'event_loop;
-                        }
-                        };
+            if let Some(config_watcher) = config_watcher.as_mut() {
+                match config_watcher.handle(readable_fds) {
+                    Ok(Some(c)) => {
+                        config = c;
+                        continue 'event_loop;
                     }
-                }
+                    _ => {
+                        continue 'event_loop;
+                    }
+                };
             }
         }
     }
@@ -359,10 +355,12 @@ fn select_readable<'a>(
     watchers: &[&Inotify],
     timer_fd: RawFd,
     timeout_manager_fd: RawFd,
+    config_watcher_fd: Option<RawFd>,
 ) -> anyhow::Result<FdSet> {
     let mut read_fds = FdSet::new();
     read_fds.insert(timer_fd);
     read_fds.insert(timeout_manager_fd);
+    config_watcher_fd.map(|fd| read_fds.insert(fd));
     for device in devices {
         read_fds.insert(device.as_raw_fd());
     }
@@ -438,41 +436,4 @@ fn handle_device_changes(
         })
     }));
     Ok(())
-}
-
-fn handle_config_changes(
-    events: Vec<InotifyEvent>,
-    config_paths: &Vec<PathBuf>,
-    inotify: Inotify,
-) -> anyhow::Result<bool> {
-    //Re-add AddWatchFlags if config file has been deleted then recreated or overwritten by renaming another file to its own name
-    for event in &events {
-        if event
-            .mask
-            .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
-        {
-            for config_path in config_paths {
-                if config_path.file_name().unwrap_or_default() == event.name.clone().unwrap_or_default() {
-                    inotify.add_watch(config_path, AddWatchFlags::IN_MODIFY)?;
-                }
-            }
-        }
-    }
-    for event in &events {
-        match (event.mask, &event.name) {
-            // Dir events
-            (_, Some(name))
-                if config_paths
-                    .iter()
-                    .any(|p| name == p.file_name().expect("Config path has a file name")) =>
-            {
-                return Ok(false)
-            }
-            // File events
-            (mask, _) if mask.contains(AddWatchFlags::IN_MODIFY) => return Ok(false),
-            // Unrelated
-            _ => (),
-        }
-    }
-    Ok(true)
 }

--- a/tests/common/xremap_controller.rs
+++ b/tests/common/xremap_controller.rs
@@ -29,6 +29,7 @@ pub struct XremapBuilder {
     ignore_device_: Option<String>,
     open_for_fetch_: bool,
     watch_: bool,
+    watch_config_: bool,
     config_file: Option<String>,
 }
 
@@ -43,6 +44,7 @@ impl XremapBuilder {
             // goes to the 'host', so disable with care.
             open_for_fetch_: true,
             watch_: false,
+            watch_config_: false,
             config_file: None,
         }
     }
@@ -75,6 +77,13 @@ impl XremapBuilder {
     pub fn watch(&mut self, value: bool) -> &mut Self {
         self.watch_ = value;
         self
+    }
+
+    pub fn watch_config(&mut self, config: &str) -> Result<&mut Self> {
+        // Custom config file is required, because static config file must not be changed.
+        self.config(config)?;
+        self.watch_config_ = true;
+        Ok(self)
     }
 
     pub fn config(&mut self, config: &str) -> Result<&mut Self> {
@@ -165,6 +174,10 @@ impl XremapController {
 
         if def.watch_ {
             builder.arg("--watch");
+        }
+
+        if def.watch_config_ {
+            builder.arg("--watch=config");
         }
 
         let device_filter = match &def.custom_input_device_ {

--- a/tests/common/xremap_controller.rs
+++ b/tests/common/xremap_controller.rs
@@ -112,6 +112,7 @@ pub struct XremapController {
     output_device_name: String,
     output_device: Option<Device>,
     device_filter: Option<String>,
+    config_file: String,
 }
 
 impl XremapController {
@@ -138,13 +139,16 @@ impl XremapController {
             .env("RUST_LOG", &def.log_level_)
             .args(vec!["--output-device-name", &output_device_name]);
 
-        match &def.config_file {
+        let config_file = match &def.config_file {
             Some(config) => {
                 println!("Using custom config: {:?}", config);
                 builder.arg(config);
+                config
             }
             None => {
-                builder.arg("tests/common/config-test.yml");
+                let config = "tests/common/config-test.yml";
+                builder.arg(config);
+                config
             }
         };
 
@@ -198,6 +202,7 @@ impl XremapController {
             output_device_name,
             output_device: None,
             device_filter,
+            config_file: config_file.to_string(),
         };
 
         match &ctrl.input_device {
@@ -222,6 +227,10 @@ impl XremapController {
 
     pub fn get_input_device_name<'a>(&'a mut self) -> &'a Option<String> {
         &self.device_filter
+    }
+
+    pub fn get_config_file<'a>(&'a mut self) -> &'a str {
+        &self.config_file
     }
 
     pub fn open_input_device(&mut self, name: impl Into<String>) -> anyhow::Result<()> {

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "device-test")]
 
-use crate::common::{assert_events, key_press, xremap_controller::XremapController};
+use crate::common::{assert_events, key_press, key_release, xremap_controller::XremapController};
 use evdev::KeyCode;
 use indoc::indoc;
 mod common;
@@ -18,7 +18,7 @@ pub fn e2e_watch_config_cur() -> anyhow::Result<()> {
         "},
     )?;
 
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(std::time::Duration::from_millis(20));
 
     ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
 
@@ -39,6 +39,7 @@ pub fn e2e_watch_config_cur() -> anyhow::Result<()> {
 pub fn e2e_old_config_remains_active_when_error_cur() -> anyhow::Result<()> {
     let mut ctrl = XremapController::builder()
         .watch_config(indoc! {"
+              config_watch_debounce_ms: 10
               keymap:
                 - remap:
                     f12: key_1
@@ -47,21 +48,21 @@ pub fn e2e_old_config_remains_active_when_error_cur() -> anyhow::Result<()> {
 
     std::fs::write(&ctrl.get_config_file(), "failed_config")?;
 
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(std::time::Duration::from_millis(20));
 
     // This is fragile without debounce, because the file write can cause
     // two events one with an empty file and one with the new content.
     // This means xremap drops the old and replace it with a 'blank' config,
     // instead of leaving the old in place.
-    // ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12), key_release(KeyCode::KEY_F12)])?;
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12), key_release(KeyCode::KEY_F12)])?;
 
-    // assert_events(
-    //     ctrl.fetch()?,
-    //     indoc! {"
-    //         1:1
-    //         1:0
-    //     "},
-    // );
+    assert_events(
+        ctrl.fetch()?,
+        indoc! {"
+            1:1
+            1:0
+        "},
+    );
 
     // Successful config can be restored
     std::fs::write(
@@ -73,7 +74,7 @@ pub fn e2e_old_config_remains_active_when_error_cur() -> anyhow::Result<()> {
         "},
     )?;
 
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(std::time::Duration::from_millis(20));
 
     ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
 
@@ -86,4 +87,43 @@ pub fn e2e_old_config_remains_active_when_error_cur() -> anyhow::Result<()> {
     );
 
     ctrl.kill()
+}
+
+#[test]
+pub fn e2e_config_watch_is_debounced_cur() -> anyhow::Result<()> {
+    let mut ctrl = XremapController::builder()
+        .watch_config("config_watch_debounce_ms: 10")?
+        .build()?;
+
+    std::fs::write(&ctrl.get_config_file(), "")?;
+    std::fs::write(&ctrl.get_config_file(), "failed_config")?;
+    std::fs::write(&ctrl.get_config_file(), "")?;
+    std::fs::write(&ctrl.get_config_file(), "other problem")?;
+    std::fs::write(
+        &ctrl.get_config_file(),
+        indoc! {"
+        keymap:
+          - remap:
+              f12: key_1
+        "},
+    )?;
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
+
+    assert_events(
+        ctrl.fetch()?,
+        indoc! {"
+            1:1
+            1:0
+        "},
+    );
+
+    let stdout = ctrl.kill_for_output()?.stdout.replacen("Reloading Config", "", 1);
+
+    // Only reloaded once
+    assert!(!stdout.contains("Reloading Config"));
+
+    Ok(())
 }

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "device-test")]
+
+use crate::common::{assert_events, key_press, xremap_controller::XremapController};
+use evdev::KeyCode;
+use indoc::indoc;
+mod common;
+
+#[test]
+pub fn e2e_watch_config_cur() -> anyhow::Result<()> {
+    let mut ctrl = XremapController::builder().watch_config("")?.build()?;
+
+    std::fs::write(
+        &ctrl.get_config_file(),
+        indoc! {"
+          keymap:
+            - remap:
+                f12: key_1
+        "},
+    )?;
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
+
+    assert_events(
+        ctrl.fetch()?,
+        indoc! {"
+            1:1
+            1:0
+        "},
+    );
+
+    assert!(ctrl.kill_for_output()?.stdout.contains("Reloading Config"));
+
+    Ok(())
+}
+
+#[test]
+pub fn e2e_old_config_remains_active_when_error_cur() -> anyhow::Result<()> {
+    let mut ctrl = XremapController::builder()
+        .watch_config(indoc! {"
+              keymap:
+                - remap:
+                    f12: key_1
+            "})?
+        .build()?;
+
+    std::fs::write(&ctrl.get_config_file(), "failed_config")?;
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // This is fragile without debounce, because the file write can cause
+    // two events one with an empty file and one with the new content.
+    // This means xremap drops the old and replace it with a 'blank' config,
+    // instead of leaving the old in place.
+    // ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12), key_release(KeyCode::KEY_F12)])?;
+
+    // assert_events(
+    //     ctrl.fetch()?,
+    //     indoc! {"
+    //         1:1
+    //         1:0
+    //     "},
+    // );
+
+    // Successful config can be restored
+    std::fs::write(
+        &ctrl.get_config_file(),
+        indoc! {"
+          keymap:
+            - remap:
+                f12: key_2
+        "},
+    )?;
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
+
+    assert_events(
+        ctrl.fetch()?,
+        indoc! {"
+            2:1
+            2:0
+        "},
+    );
+
+    ctrl.kill()
+}


### PR DESCRIPTION
Watching configuration files for change can give more than one event per config save. E.g. an event where the config file is empty and then an event for the new content. This means the configuration will be unloaded and then loaded.

This becomes a problem, when the second load fails (e.g. parse error in config file), because then is the configuration only unloaded, which is surprising.

This PR adds an option `config_watch_debounce_ms: u64` which waits until no events have appeared for `config_watch_debounce_ms`, so the config file has become stable.

