### PR TITLE
Add ready and config-fail notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ is supported only in `modmap` since `keymap` handles modifier keys differently.
 ```yml
 modmap:
   - name: Name # Optional
-    exact_match: false # Optional, defaults to false
     remap: # Required
       # Replace a key with another
       KEY_XXX1: KEY_YYY # Required

--- a/doc/reference_config_options.md
+++ b/doc/reference_config_options.md
@@ -17,7 +17,10 @@ keymap:
 
 ### keypress_delay_ms
 
-Default is `0ms`.
+```yml
+keypress_delay_ms: 10 # Default is `0`
+# Rest of your config file
+```
 
 Some applications have trouble understanding synthesized key events, especially on
 Wayland. `keypress_delay_ms` can be used to workaround the issue. Only events from
@@ -25,7 +28,10 @@ key combos in `keymap` are delayed. If that isn't enough try `throttle_ms`.
 
 ### throttle_ms
 
-Default is `0ms`.
+```yml
+throttle_ms: 10 # Default is `0`
+# Rest of your config file
+```
 
 Slow down synthetic events, so applications have the time to register events.
 All events from anywhere in xremap are slowed down between:
@@ -38,6 +44,29 @@ The delay is only added if needed. That is there's no delay if the time has alre
 
 The logic is choosen to allow applications enough time to register the exact modifiers pressed when
 a key is pressed, and keep to key pressed enough time.
+
+Since version 0.14.14.
+
+### default_mode
+
+```yml
+default_mode: my_start_mode # Default is "default"
+# Rest of your config file
+```
+
+This will be the value of `mode` when `xremap` starts. `mode` [is described here](../README.md#mode).
+
+### notififactions
+
+```yml
+notififactions: true # Default is false
+# Rest of your config file
+```
+
+With `true` will all desktop notifications from xremap be shown. This is currently a message when xremap
+is loaded, when configuration files are reloaded and when reloading configuration files fails.
+
+Since version 0.15.1.
 
 ### config_watch_debounce_ms
 
@@ -78,3 +107,15 @@ keymap:
       only: *terminals # we can reuse the list here
     remap: *some_remaps # and we can reuse a map here.
 ```
+
+### enable_wheel
+
+```yml
+enable_wheel: false # Default is "true"
+# Rest of your config file
+```
+
+By default will the output device created by xremap support the mouse events `REL_X`, `REL_Y`, `REL_HWHEEL`, `REL_WHEEL`.
+This does not affect the events/devices that are listened to, see the commandline argument `--mouse` for that.
+
+With `enable_wheel: false` will the output device not support `REL_HWHEEL`, `REL_WHEEL`.

--- a/doc/reference_double_tap.md
+++ b/doc/reference_double_tap.md
@@ -16,7 +16,7 @@ experimental_map:
   - remap:
       LeftMeta:
         double: mute
-        timeout: 200 # Optional. Default is 200ms.
+        timeout: 200 # Optional. Default is 200. Meaning 200ms.
 ```
 
 Working since v0.14.18
@@ -68,7 +68,7 @@ experimental_map:
   - remap:
       btn_right:
         double: R
-        timeout: 200 # Optional. Default is 200ms.
+        timeout: 200 # Optional. Default is 200. Meaning 200ms.
 ```
 
 To use mouse buttons xremap must be started with the `--mouse` argument.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -30,7 +30,7 @@ This might be caused by key events emitted to fast by xremap. You can add a dela
 
 ```yml
 keypress_delay_ms: 10
-# Rest of you config file
+# Rest of your config file
 ```
 
 `10 ms` is good default value, but try `100 ms` to be certain if this is the cause of your problems.
@@ -40,7 +40,7 @@ Another way to slow events down is:
 
 ```yml
 throttle_ms: 10
-# Rest of you config file
+# Rest of your config file
 ```
 
 ### Application-specific remappings don't work

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -113,3 +113,15 @@ sudo modprobe uinput
 ```
 
 If it doesn't work reboot is needed.
+
+### Error running command: ["notify-send", "-a", "xremap", "Ready"]
+
+When xremap sends notifications it uses a binary called `notify-send`. It's installed on most distros, but
+if it's not, here are examples of how to install:
+
+```sh
+sudo apt install libnotify-bin
+sudo dnf install notify-send
+sudo pacman --sync libnotify
+sudo zypper install libnotify-tools
+```

--- a/src/client/hypr_client.rs
+++ b/src/client/hypr_client.rs
@@ -13,6 +13,7 @@ impl Client for HyprlandClient {
     fn supported(&mut self) -> bool {
         true
     }
+
     fn current_window(&mut self) -> Option<String> {
         if let Ok(win_opt) = HyprClient::get_active() {
             if let Some(win) = win_opt {

--- a/src/client/kde/kde_client.rs
+++ b/src/client/kde/kde_client.rs
@@ -213,6 +213,7 @@ impl Client for KdeClient {
         }
         conn_res.is_ok()
     }
+
     fn current_window(&mut self) -> Option<String> {
         let aw = self.active_window.lock().ok()?;
         Some(aw.title.clone())

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -136,6 +136,8 @@ pub fn build_client(log_window_changes: bool) -> WMClient {
         WMClient::new("COSMIC", Box::new(cosmic_client::CosmicClient::new()), log_window_changes),
         #[cfg(feature = "socket")]
         WMClient::new("Socket", Box::new(socket_client::SocketClient::new()), log_window_changes),
+        #[cfg(feature = "device-test")]
+        WMClient::new("DeviceTest", Box::new(null_client::DeviceTestClient), log_window_changes),
     ];
 
     if clients.len() == 0 {

--- a/src/client/null_client.rs
+++ b/src/client/null_client.rs
@@ -6,12 +6,42 @@ impl Client for NullClient {
     fn supported(&mut self) -> bool {
         false
     }
+
     fn current_window(&mut self) -> Option<String> {
         None
     }
 
     fn current_application(&mut self) -> Option<String> {
         None
+    }
+
+    fn window_list(&mut self) -> anyhow::Result<Vec<WindowInfo>> {
+        Ok(vec![])
+    }
+}
+
+/// This should properly be in the test module.
+/// But then wouldn't main-module be able to load it.
+#[cfg(feature = "device-test")]
+pub struct DeviceTestClient;
+
+#[cfg(feature = "device-test")]
+impl Client for DeviceTestClient {
+    fn supported(&mut self) -> bool {
+        true
+    }
+
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
+
+    fn current_application(&mut self) -> Option<String> {
+        None
+    }
+
+    fn run(&mut self, command: &Vec<String>) -> anyhow::Result<bool> {
+        println!("{:?}", command);
+        Ok(true)
     }
 
     fn window_list(&mut self) -> anyhow::Result<Vec<WindowInfo>> {

--- a/src/client/wlroots_client.rs
+++ b/src/client/wlroots_client.rs
@@ -58,6 +58,7 @@ impl Client for WlRootsClient {
             }
         }
     }
+
     fn current_window(&mut self) -> Option<String> {
         let queue = self.queue.as_mut()?;
 

--- a/src/client/x11_client.rs
+++ b/src/client/x11_client.rs
@@ -56,6 +56,7 @@ impl Client for X11Client {
         return self.connection.is_some();
         // TODO: Test XGetInputFocus and focused_window > 0?
     }
+
     fn current_window(&mut self) -> Option<String> {
         self.connect();
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,6 +54,8 @@ pub struct Config {
     pub throttle_ms: u64,
     #[serde(default)]
     pub config_watch_debounce_ms: u64,
+    #[serde(default)]
+    pub notifications: bool,
 
     // Data is not used by any part of the application.
     // but can be used with Anchors and Aliases

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -1,4 +1,5 @@
 use crate::config::{load_configs, Config};
+use crate::main_controller::MainController;
 use anyhow::Result;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, InotifyEvent};
 use nix::sys::select::FdSet;
@@ -12,6 +13,7 @@ use std::time::Duration;
 pub struct ConfigWatcher {
     files: Vec<PathBuf>,
     debounce: Option<Duration>,
+    notifications: bool,
     timer_fd: RawFd,
     timer: TimerFd,
     inotify: Inotify,
@@ -23,6 +25,7 @@ impl ConfigWatcher {
         watch: bool,
         files: Vec<PathBuf>,
         debounce_ms: u64,
+        notifications: bool,
     ) -> Result<(Option<RawFd>, Option<Inotify>, Option<Self>)> {
         if !watch {
             return Ok((None, None, None));
@@ -48,6 +51,7 @@ impl ConfigWatcher {
         let this = Self {
             files,
             debounce,
+            notifications,
             timer_fd: timer.as_raw_fd(),
             timer,
             inotify,
@@ -57,9 +61,9 @@ impl ConfigWatcher {
         Ok((Some(this.timer_fd), Some(this.inotify), Some(this)))
     }
 
-    pub fn handle(&mut self, readable_fds: FdSet) -> Result<Option<Config>> {
+    pub fn handle(&mut self, readable_fds: FdSet, mainctrl: &mut MainController) -> Result<Option<Config>> {
         if readable_fds.contains(self.timer_fd) {
-            return Ok(Some(self.get_config()?));
+            return Ok(Some(self.get_config(mainctrl)?));
         }
 
         if let Ok(events) = self.inotify.read_events() {
@@ -72,7 +76,7 @@ impl ConfigWatcher {
                             .set(Expiration::OneShot(TimeSpec::from_duration(debounce)), TimerSetTimeFlags::empty())?;
                     }
                     None => {
-                        return Ok(Some(self.get_config()?));
+                        return Ok(Some(self.get_config(mainctrl)?));
                     }
                 };
             }
@@ -81,7 +85,7 @@ impl ConfigWatcher {
         Ok(None)
     }
 
-    fn get_config(&mut self) -> Result<Config> {
+    fn get_config(&mut self, mainctrl: &mut MainController) -> Result<Config> {
         self.change_pending = false;
         self.timer.unset()?;
         let result = load_configs(&self.files);
@@ -89,7 +93,11 @@ impl ConfigWatcher {
             Ok(_) => {
                 println!("Reloading Config");
             }
-            Err(_) => {}
+            Err(err) => {
+                if self.notifications {
+                    mainctrl.show_popup("Config error", Some(&err.to_string()));
+                }
+            }
         }
 
         result.map_err(|err| anyhow::format_err!("{err}"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,7 @@ fn main() -> anyhow::Result<()> {
     };
     let device_watcher = device_watcher(watch_devices).context("Setting up device watcher")?;
     let (config_watcher_fd, config_watcher_inotify, mut config_watcher) =
-        ConfigWatcher::new(watch_config, config_paths, config.config_watch_debounce_ms)?;
+        ConfigWatcher::new(watch_config, config_paths, config.config_watch_debounce_ms, config.notifications)?;
     let watchers: Vec<_> = device_watcher.iter().chain(config_watcher_inotify.iter()).collect();
 
     // wmclient
@@ -270,6 +270,10 @@ fn main() -> anyhow::Result<()> {
 
     // Main loop
     loop {
+        if config.notifications {
+            mainctrl.show_popup("Ready", None);
+        }
+
         'event_loop: loop {
             let readable_fds =
                 select_readable(input_devices.values(), &watchers, timer_fd, timeout_manager_fd, config_watcher_fd)?;
@@ -336,10 +340,10 @@ fn main() -> anyhow::Result<()> {
             }
 
             if let Some(config_watcher) = config_watcher.as_mut() {
-                match config_watcher.handle(readable_fds) {
+                match config_watcher.handle(readable_fds, &mut mainctrl) {
                     Ok(Some(c)) => {
                         config = c;
-                        continue 'event_loop;
+                        break 'event_loop;
                     }
                     _ => {
                         continue 'event_loop;

--- a/src/main_controller.rs
+++ b/src/main_controller.rs
@@ -38,4 +38,21 @@ impl MainController {
             }
         }
     }
+
+    pub fn show_popup(&mut self, title: &str, msg: Option<&str>) {
+        match msg {
+            Some(msg) => {
+                self.run_command(vec![
+                    "notify-send".into(),
+                    "-a".into(),
+                    "xremap".into(),
+                    title.into(),
+                    msg.into(),
+                ]);
+            }
+            None => {
+                self.run_command(vec!["notify-send".into(), "-a".into(), "xremap".into(), title.into()]);
+            }
+        };
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -150,3 +150,30 @@ pub fn assert_events(actual: impl AsRef<Vec<InputEvent>>, expected: &str) {
 
     assert_eq!(actual, expected);
 }
+
+pub fn containsn(count: u64, hackstack: &str, needle: &str) -> bool {
+    let mut hackstack = hackstack.to_string();
+
+    for _ in 0..count {
+        if !hackstack.contains(needle) {
+            return false;
+        }
+
+        hackstack = hackstack.replacen(needle, "", 1);
+    }
+
+    !hackstack.contains(needle)
+}
+
+#[test]
+pub fn test_containsn() {
+    assert!(containsn(0, "", "foo"));
+    assert!(!containsn(1, "", "foo"));
+    assert!(!containsn(2, "", "foo"));
+    assert!(!containsn(0, "foo", "foo"));
+    assert!(containsn(1, "foo", "foo"));
+    assert!(!containsn(2, "foo", "foo"));
+    assert!(!containsn(0, "foo foo", "foo"));
+    assert!(!containsn(1, "foo foo", "foo"));
+    assert!(containsn(2, "foo foo", "foo"));
+}

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "device-test")]
 
-use crate::common::{assert_events, key_press, key_release, xremap_controller::XremapController};
+use crate::common::{assert_events, containsn, key_press, key_release, xremap_controller::XremapController};
 use evdev::KeyCode;
 use indoc::indoc;
 mod common;
@@ -120,10 +120,9 @@ pub fn e2e_config_watch_is_debounced_cur() -> anyhow::Result<()> {
         "},
     );
 
-    let stdout = ctrl.kill_for_output()?.stdout.replacen("Reloading Config", "", 1);
+    let stdout = ctrl.kill_for_output()?.stdout;
 
-    // Only reloaded once
-    assert!(!stdout.contains("Reloading Config"));
+    assert!(containsn(1, &stdout, "Reloading Config"));
 
     Ok(())
 }

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -6,7 +6,7 @@ use indoc::indoc;
 mod common;
 
 #[test]
-pub fn e2e_watch_config_cur() -> anyhow::Result<()> {
+pub fn e2e_watch_config() -> anyhow::Result<()> {
     let mut ctrl = XremapController::builder().watch_config("")?.build()?;
 
     std::fs::write(
@@ -36,7 +36,7 @@ pub fn e2e_watch_config_cur() -> anyhow::Result<()> {
 }
 
 #[test]
-pub fn e2e_old_config_remains_active_when_error_cur() -> anyhow::Result<()> {
+pub fn e2e_old_config_remains_active_when_error() -> anyhow::Result<()> {
     let mut ctrl = XremapController::builder()
         .watch_config(indoc! {"
               config_watch_debounce_ms: 10
@@ -90,7 +90,7 @@ pub fn e2e_old_config_remains_active_when_error_cur() -> anyhow::Result<()> {
 }
 
 #[test]
-pub fn e2e_config_watch_is_debounced_cur() -> anyhow::Result<()> {
+pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
     let mut ctrl = XremapController::builder()
         .watch_config("config_watch_debounce_ms: 10")?
         .build()?;
@@ -122,6 +122,32 @@ pub fn e2e_config_watch_is_debounced_cur() -> anyhow::Result<()> {
 
     let stdout = ctrl.kill_for_output()?.stdout;
 
+    assert!(containsn(1, &stdout, "Reloading Config"));
+
+    Ok(())
+}
+
+#[test]
+pub fn e2e_config_watch_with_notifications() -> anyhow::Result<()> {
+    let config = indoc! {"
+            notifications: true
+            config_watch_debounce_ms: 10
+        "};
+
+    let mut ctrl = XremapController::builder().watch_config(config)?.build()?;
+
+    std::fs::write(&ctrl.get_config_file(), "failed_config")?;
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    std::fs::write(&ctrl.get_config_file(), config)?;
+
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    let stdout = ctrl.kill_for_output()?.stdout;
+
+    assert!(containsn(2, &stdout, r#"["notify-send", "-a", "xremap", "Ready"]"#));
+    assert!(containsn(1, &stdout, r#"["notify-send", "-a", "xremap", "Config error""#));
     assert!(containsn(1, &stdout, "Reloading Config"));
 
     Ok(())


### PR DESCRIPTION
This PR adds a configuration option for notifications. The messages are when xremap
is loaded, when configuration files are reloaded and when reloading configuration files fail.

The last two are only relevant for `--watch`.
