### PR TITLE
Fix device watch errors and race-conditions

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -254,29 +254,46 @@ impl AsRawFd for InputDevice {
 
 /// Device Wrappers Abstractions
 impl InputDevice {
-    pub fn wait_for_all_keys_up(&self) -> io::Result<()> {
+    /// Returns true when all keys have been released.
+    pub fn wait_for_all_keys_up(&self) -> bool {
         #[cfg(not(feature = "device-test"))]
         let count = 50;
         #[cfg(feature = "device-test")]
         let count = 2;
 
         for _ in 0..count {
-            let keys = self.device.get_key_state()?;
-
-            if keys.iter().filter(|&key| key != Key::KEY_UNKNOWN).count() == 0 {
-                return Ok(());
-            }
-
-            std::thread::sleep(Duration::from_millis(100));
+            match self.device.get_key_state() {
+                Ok(keys) => {
+                    if keys.iter().filter(|&key| key != Key::KEY_UNKNOWN).count() == 0 {
+                        return true;
+                    } else {
+                        std::thread::sleep(Duration::from_millis(100));
+                    }
+                }
+                Err(err) if err.raw_os_error() == Some(ENODEV) => {
+                    // Must be a race-condition, so don't print error.
+                    return false;
+                }
+                Err(err) => {
+                    eprintln!(
+                        "Error: {err}. Error happened while waiting for keys to be released on: '{}'",
+                        self.device_name()
+                    );
+                    return false;
+                }
+            };
         }
 
-        Err(io::Error::new(io::ErrorKind::TimedOut, "Timed out waiting for keys to be released."))
+        eprintln!("Timed out waiting for keys to be released on: '{}'", self.device_name());
+        false
     }
 
     pub fn grab(&mut self) -> bool {
-        let result = self.wait_for_all_keys_up().and_then(|_| self.device.grab());
+        if !self.wait_for_all_keys_up() {
+            return false;
+        }
 
-        match result {
+        match self.device.grab() {
             Ok(_) => true,
             Err(err) if err.raw_os_error() == Some(ENODEV) => {
                 // There's no point of printing errors when devices don't exist, because
@@ -286,7 +303,7 @@ impl InputDevice {
             }
             Err(error) => {
                 eprintln!(
-                    "warning: Failed to grab device '{}' at '{}'. It may have been disconnected, have keys held down, or you may need to grant permissions. Error: {}",
+                    "warning: Failed to grab device '{}' at '{}'. You may need to grant permissions. Error: {}",
                     self.device_name(),
                     self.path.display(),
                     error

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,7 +3,7 @@ use derive_where::derive_where;
 use evdev::uinput::VirtualDevice;
 use evdev::{AttributeSet, BusType, Device, FetchEventsSynced, InputId, KeyCode as Key, RelativeAxisCode};
 use log::debug;
-use nix::libc::ENODEV;
+use nix::libc::{EBUSY, ENODEV};
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use std::collections::HashMap;
 #[cfg(feature = "udev")]
@@ -303,6 +303,10 @@ impl InputDevice {
                 // There's no point of printing errors when devices don't exist, because
                 // this function is only called just after the information is received, that the device
                 // does exist. So it's a race-condition, where the device was quickly removed.
+                false
+            }
+            Err(err) if err.raw_os_error() == Some(EBUSY) => {
+                eprintln!("Error: {err}. Another program might have grabbed the device: '{}'", self.device_name());
                 false
             }
             Err(error) => {

--- a/src/device.rs
+++ b/src/device.rs
@@ -254,7 +254,12 @@ impl AsRawFd for InputDevice {
 /// Device Wrappers Abstractions
 impl InputDevice {
     pub fn wait_for_all_keys_up(&self) -> io::Result<()> {
-        for _ in 0..50 {
+        #[cfg(not(feature = "device-test"))]
+        let count = 50;
+        #[cfg(feature = "device-test")]
+        let count = 2;
+
+        for _ in 0..count {
             let keys = self.device.get_key_state()?;
 
             if keys.iter().filter(|&key| key != Key::KEY_UNKNOWN).count() == 0 {

--- a/src/device.rs
+++ b/src/device.rs
@@ -101,9 +101,13 @@ pub fn select_input_devices(
     let mut devices = input_devices()?;
     devices.sort();
 
-    println!("Selecting devices from the following list:");
-    println!("{SEPARATOR}");
-    devices.iter().for_each(InputDevice::print);
+    if devices.is_empty() {
+        println!("No input devices. It's probably because you lack the required permissions.");
+    } else {
+        println!("Selecting devices from the following list:");
+        println!("{SEPARATOR}");
+        devices.iter().for_each(InputDevice::print);
+    }
     println!("{SEPARATOR}");
 
     if device_opts.is_empty() {

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,6 +3,7 @@ use derive_where::derive_where;
 use evdev::uinput::VirtualDevice;
 use evdev::{AttributeSet, BusType, Device, FetchEventsSynced, InputId, KeyCode as Key, RelativeAxisCode};
 use log::debug;
+use nix::libc::ENODEV;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use std::collections::HashMap;
 #[cfg(feature = "udev")]
@@ -277,6 +278,12 @@ impl InputDevice {
 
         match result {
             Ok(_) => true,
+            Err(err) if err.raw_os_error() == Some(ENODEV) => {
+                // There's no point of printing errors when devices don't exist, because
+                // this function is only called just after the information is received, that the device
+                // does exist. So it's a race-condition, where the device was quickly removed.
+                false
+            }
             Err(error) => {
                 eprintln!(
                     "warning: Failed to grab device '{}' at '{}'. It may have been disconnected, have keys held down, or you may need to grant permissions. Error: {}",

--- a/src/device.rs
+++ b/src/device.rs
@@ -131,7 +131,7 @@ pub fn select_input_devices(
 
     if selected.is_empty() {
         if watch {
-            println!("warning: No device was selected, but --watch is waiting for new devices.");
+            println!("No device was selected, but --watch is waiting for new devices.");
         } else {
             bail!("Failed to prepare input devices: No device was selected!");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,8 +431,18 @@ fn handle_device_changes(
     mouse: bool,
     own_device: &str,
 ) {
+    // Ignore already grabbed devices.
+    // A problem that could occur is an old device in `input_devices` which is stale.
+    // So ignoring an event for that path would be incorrect. But `handle_input_events` removes
+    // the devices reliably, before this function gets an event for a new devive on the same path.
+    let mut ignore: Vec<PathBuf> = input_devices.iter().map(|(path, _)| path).cloned().collect();
+
     input_devices.extend(events.into_iter().filter_map(|event| {
         let path = PathBuf::from("/dev/input/").join(event.name?);
+        if ignore.contains(&path) {
+            return None;
+        }
+        ignore.push(path.clone());
         let mut device = open_device(path)?;
         if device.is_input_device(device_filter, ignore_filter, mouse, own_device) && device.grab() {
             device.print();

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,14 +313,17 @@ fn main() -> anyhow::Result<()> {
                     &mut operator_handler,
                     &mut mainctrl,
                 )? {
-                    println!("Found a removed device. Reselecting devices.");
+                    let device_info = input_device.to_info();
+                    println!("Found a removed device: {:?}", device_info.name);
+                    input_devices.retain(|path, _| device_info.path != *path);
 
-                    for input_device in input_devices.values_mut() {
-                        input_device.ungrab();
+                    if input_devices.is_empty() {
+                        if watch_devices {
+                            println!("No device was selected, but --watch is waiting for new devices.");
+                        } else {
+                            bail!("Last device was removed, and not watching for new devices");
+                        }
                     }
-
-                    input_devices =
-                        select_input_devices(&device_filter, &ignore_filter, mouse, watch_devices, &own_device)?;
 
                     continue 'event_loop;
                 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,9 +4,13 @@ pub mod inputevent_formatter;
 pub mod xremap_controller;
 
 use crate::common::inputevent_formatter::get_pretty_events;
+use anyhow::bail;
 use evdev::uinput::VirtualDevice;
-use evdev::{AttributeSet, BusType, Device, EventType, InputEvent, InputId, KeyCode, SwitchCode};
+use evdev::{AttributeSet, BusType, Device, EventType, FetchEventsSynced, InputEvent, InputId, KeyCode, SwitchCode};
+use nix::sys::select::{select, FdSet};
+use nix::sys::time::TimeValLike;
 use std::iter::repeat_with;
+use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::time::Duration;
 use xremap::util::{until, until_value};
@@ -163,6 +167,20 @@ pub fn containsn(count: u64, hackstack: &str, needle: &str) -> bool {
     }
 
     !hackstack.contains(needle)
+}
+
+pub fn fetch_events(device: &mut Device) -> anyhow::Result<FetchEventsSynced<'_>> {
+    let mut fds = FdSet::new();
+    let fd = device.as_raw_fd();
+    fds.insert(fd);
+
+    select(None, &mut fds, None, None, Some(&mut TimeValLike::seconds(1)))?;
+
+    if !fds.contains(fd) {
+        bail!("Timed out waiting for xremap events.");
+    }
+
+    Ok(device.fetch_events()?)
 }
 
 #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -47,7 +47,7 @@ pub fn get_random_device_name() -> String {
     format!("test device {}", repeat_with(fastrand::alphanumeric).take(10).collect::<String>())
 }
 
-pub fn get_virtual_device(name: impl Into<String>) -> anyhow::Result<VirtualDeviceInfo> {
+pub fn get_virtual_device_without_wait(name: impl Into<String>) -> anyhow::Result<VirtualDevice> {
     let name = name.into();
 
     let mut keys: AttributeSet<KeyCode> = AttributeSet::new();
@@ -70,6 +70,13 @@ pub fn get_virtual_device(name: impl Into<String>) -> anyhow::Result<VirtualDevi
         .with_keys(&keys)?
         .with_switches(&sw)?
         .build()?;
+
+    Ok(device)
+}
+
+pub fn get_virtual_device(name: impl Into<String>) -> anyhow::Result<VirtualDeviceInfo> {
+    let name = name.into();
+    let device = get_virtual_device_without_wait(&name)?;
 
     // Fetch path.
     let (path, _) = wait_for_device(&name)?;

--- a/tests/common/xremap_controller.rs
+++ b/tests/common/xremap_controller.rs
@@ -1,14 +1,11 @@
 use crate::common::{
-    get_random_device_name, get_virtual_device, key_press, key_release, wait_for_device, wait_for_grabbed,
-    VirtualDeviceInfo,
+    fetch_events, get_random_device_name, get_virtual_device, key_press, key_release, wait_for_device,
+    wait_for_grabbed, VirtualDeviceInfo,
 };
 use anyhow::{bail, Result};
 use evdev::{Device, EventType, FetchEventsSynced, InputEvent, KeyCode as Key};
-use nix::sys::select::{select, FdSet};
-use nix::sys::time::TimeValLike;
 use std::cell::Cell;
 use std::iter::repeat_with;
-use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -307,19 +304,7 @@ impl XremapController {
     }
 
     pub fn fetch_events(&mut self) -> anyhow::Result<FetchEventsSynced<'_>> {
-        let device = self.output_device.as_mut().expect("Output device is not opened");
-
-        let mut fds = FdSet::new();
-        let fd = device.as_raw_fd();
-        fds.insert(fd);
-
-        select(None, &mut fds, None, None, Some(&mut TimeValLike::seconds(1)))?;
-
-        if !fds.contains(fd) {
-            bail!("Timed out waiting for xremap events.");
-        }
-
-        Ok(device.fetch_events()?)
+        fetch_events(self.output_device.as_mut().expect("Output device is not opened"))
     }
 
     pub fn fetch_until_key(&mut self, key: Key) -> anyhow::Result<Vec<InputEvent>> {

--- a/tests/common/xremap_controller.rs
+++ b/tests/common/xremap_controller.rs
@@ -21,6 +21,7 @@ pub enum InputDeviceFilter {
 pub struct XremapBuilder {
     nocapture_: bool,
     log_level_: String,
+    allow_stdio_errors_: bool,
     // None means open a new input device
     custom_input_device_: InputDeviceFilter,
     ignore_device_: Option<String>,
@@ -35,6 +36,7 @@ impl XremapBuilder {
         Self {
             nocapture_: false,
             log_level_: "debug".into(),
+            allow_stdio_errors_: false,
             custom_input_device_: InputDeviceFilter::RandomName,
             ignore_device_: None,
             // If output from xremap isn't grabbed, the events
@@ -53,6 +55,11 @@ impl XremapBuilder {
 
     pub fn log_level(&mut self, log_level: impl Into<String>) -> &mut Self {
         self.log_level_ = log_level.into();
+        self
+    }
+
+    pub fn allow_stdio_errors(&mut self, allow_stdio_errors: bool) -> &mut Self {
+        self.allow_stdio_errors_ = allow_stdio_errors;
         self
     }
 
@@ -112,6 +119,7 @@ pub struct XremapController {
     // Is None when xremap has been stopped.
     child: Cell<Option<Child>>,
     nocapture: bool,
+    allow_stdio_errors: bool,
     // Input from xremap's perspective
     input_device: Option<VirtualDeviceInfo>,
     // Output from xremap's perspective
@@ -208,6 +216,7 @@ impl XremapController {
         let mut ctrl = Self {
             child: Cell::new(Some(child)),
             nocapture: def.nocapture_,
+            allow_stdio_errors: def.allow_stdio_errors_,
             input_device,
             output_device_name,
             output_device: None,
@@ -394,13 +403,33 @@ impl XremapController {
             println!("{SEPARATOR}");
         }
 
+        if !self.allow_stdio_errors {
+            Self::check_stdio(&stdout)?;
+            Self::check_stdio(&stderr)?;
+        }
+
         match is_stopped {
             Ok(_) => Ok(Output { stdout, stderr }),
             Err(e) => Err(e),
         }
     }
 
-    pub fn raw_kill(&self) -> anyhow::Result<()> {
+    fn check_stdio(stdio: &str) -> anyhow::Result<()> {
+        // Ignore an error from evdev that goes straight to stderr, open PR:https://github.com/emberian/evdev/pull/172
+        let stdio = stdio.replace("Failed to ungrab device: No such device (os error 19)", "");
+        let stdio = stdio.to_ascii_lowercase();
+        if stdio.contains("fail")
+            || stdio.contains("fatal")
+            || stdio.contains("error")
+            || stdio.contains("panic")
+            || stdio.contains("warn")
+        {
+            bail!("Stdio contained an error message")
+        }
+        Ok(())
+    }
+
+    fn raw_kill(&self) -> anyhow::Result<()> {
         let mut child = self.child.take().expect("Output is already fetched.");
 
         let result = child.kill();
@@ -417,11 +446,12 @@ impl XremapController {
         if let Some(mut child) = self.child.take() {
             if child.try_wait()?.is_none() {
                 child.kill()?;
-
                 println!("Xremap killed");
             } else {
                 println!("Xremap already stopped when attempting to kill.");
             }
+
+            let _ = self.wait_for_output_inner(child)?;
         } else {
             println!("Some sort of shutdown has already been requested.");
         }

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -10,6 +10,7 @@ pub fn e2e_device_filter_does_not_match() -> anyhow::Result<()> {
         .input_device(InputDeviceFilter::CustomFilter {
             filter: "match_nothing".into(),
         })
+        .allow_stdio_errors(true)
         .not_open_for_fetch()
         .build()?;
 

--- a/tests/controller.rs
+++ b/tests/controller.rs
@@ -21,6 +21,7 @@ pub fn e2e_keeps_running() -> anyhow::Result<()> {
 pub fn e2e_get_device_that_xremap_never_opens() -> anyhow::Result<()> {
     // Fails and exits without opening a VirtualDevice
     let mut ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
         .input_device(InputDeviceFilter::CustomFilter {
             filter: "match_nothing".into(),
         })
@@ -64,6 +65,7 @@ pub fn e2e_wait_for_output_with_nocapture() -> anyhow::Result<()> {
 #[test]
 pub fn e2e_error_in_config_file() -> Result<()> {
     let ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
         .config(indoc! {"
                 keymap:
                     - remap:

--- a/tests/device.rs
+++ b/tests/device.rs
@@ -67,6 +67,7 @@ pub fn test_device_filter_overwrites_keyboard_and_mouse_check() -> Result<()> {
 pub fn test_device_that_does_not_exist() -> Result<()> {
     // The device path doesn't exist, so will not cause other errors than no devices selected
     let ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
         .not_open_for_fetch()
         .input_device(InputDeviceFilter::CustomFilter {
             filter: "/dev/input/event99".into(),
@@ -85,6 +86,7 @@ pub fn test_device_that_is_already_grabbed() -> Result<()> {
     let (mut input, output) = get_raw_device_pair()?;
 
     let mut ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
         .not_open_for_fetch()
         .input_device(InputDeviceFilter::CustomFilter {
             filter: output.path.to_string_lossy().into(),
@@ -105,7 +107,7 @@ pub fn test_device_that_is_already_grabbed() -> Result<()> {
 
 #[test]
 pub fn test_last_device_removed_in_non_watch_mode() -> Result<()> {
-    let mut ctrl = XremapController::builder().build()?;
+    let mut ctrl = XremapController::builder().allow_stdio_errors(true).build()?;
 
     ctrl.close_input_device()?;
 
@@ -160,6 +162,7 @@ pub fn test_wait_for_all_up_keys_up_fails() -> Result<()> {
     device.device.emit(&[key_press(Key::BTN_TRIGGER_HAPPY1)])?;
 
     let ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
         .not_open_for_fetch()
         .input_device(InputDeviceFilter::CustomFilter { filter: name.clone() })
         .build()?;

--- a/tests/device.rs
+++ b/tests/device.rs
@@ -112,7 +112,7 @@ pub fn test_last_device_removed_in_non_watch_mode() -> Result<()> {
     // Can wait because xremap exits in this case
     let output = ctrl.wait_for_output()?;
 
-    assert_str_contains("Failed to prepare input devices: No device was selected!", &output.stderr);
+    assert_str_contains("Last device was removed, and not watching for new devices", &output.stderr);
 
     Ok(())
 }

--- a/tests/device.rs
+++ b/tests/device.rs
@@ -101,6 +101,7 @@ pub fn test_device_that_is_already_grabbed() -> Result<()> {
 
     assert_str_contains("Failed to prepare input devices", &output.stderr);
     assert_str_contains("Device or resource busy", &output.stderr);
+    assert_str_contains("Another program might have grabbed the device", &output.stderr);
 
     Ok(())
 }

--- a/tests/device.rs
+++ b/tests/device.rs
@@ -1,9 +1,14 @@
 #![cfg(feature = "device-test")]
 
 use crate::common::xremap_controller::{InputDeviceFilter, XremapController};
-use crate::common::{assert_err, assert_str_contains, get_random_device_name, get_raw_device_pair, wait_for_device};
+use crate::common::{
+    assert_err, assert_events, assert_str_contains, fetch_events, get_random_device_name, get_raw_device_pair,
+    get_virtual_device, key_press, key_release, wait_for_device,
+};
 use anyhow::Result;
 use evdev::uinput::VirtualDevice;
+use evdev::{Device, KeyCode as Key};
+use indoc::indoc;
 use std::time::Duration;
 use xremap::device::select_input_devices;
 
@@ -94,6 +99,77 @@ pub fn test_device_that_is_already_grabbed() -> Result<()> {
 
     assert_str_contains("Failed to prepare input devices", &output.stderr);
     assert_str_contains("Device or resource busy", &output.stderr);
+
+    Ok(())
+}
+
+#[test]
+pub fn test_last_device_removed_in_non_watch_mode() -> Result<()> {
+    let mut ctrl = XremapController::builder().build()?;
+
+    ctrl.close_input_device()?;
+
+    // Can wait because xremap exits in this case
+    let output = ctrl.wait_for_output()?;
+
+    assert_str_contains("Failed to prepare input devices: No device was selected!", &output.stderr);
+
+    Ok(())
+}
+
+#[test]
+pub fn test_wait_for_all_up_keys_up() -> Result<()> {
+    let name = get_random_device_name();
+    let mut device = get_virtual_device(&name)?;
+    let mut input = Device::open(&device.path)?; // Open without grabbing
+
+    // A key that likely has no effect
+    device.device.emit(&[key_press(Key::BTN_TRIGGER_HAPPY1)])?;
+
+    let ctrl = XremapController::builder()
+        .not_open_for_fetch()
+        .input_device(InputDeviceFilter::CustomFilter { filter: name.clone() })
+        .build()?;
+
+    // Allow xremap to go into wait-for-keys-loop
+    std::thread::sleep(Duration::from_millis(100));
+    device.device.emit(&[key_release(Key::BTN_TRIGGER_HAPPY1)])?;
+
+    // Allow xremap to grab
+    std::thread::sleep(Duration::from_millis(200));
+
+    // The release event was not swallowed by xremap
+    let events: Vec<_> = fetch_events(&mut input)?.collect();
+    assert_events(
+        events,
+        indoc! {"
+            btn_trigger_happy1:1
+            btn_trigger_happy1:0
+        "},
+    );
+
+    ctrl.kill()
+}
+
+#[test]
+pub fn test_wait_for_all_up_keys_up_fails() -> Result<()> {
+    let name = get_random_device_name();
+    let mut device = get_virtual_device(&name)?;
+
+    // A key that likely has no effect
+    device.device.emit(&[key_press(Key::BTN_TRIGGER_HAPPY1)])?;
+
+    let ctrl = XremapController::builder()
+        .not_open_for_fetch()
+        .input_device(InputDeviceFilter::CustomFilter { filter: name.clone() })
+        .build()?;
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let output = ctrl.wait_for_output()?;
+
+    assert_str_contains("Failed to prepare input devices", &output.stderr);
+    assert_str_contains("Timed out waiting for keys to be released", &output.stderr);
 
     Ok(())
 }

--- a/tests/device_1.rs
+++ b/tests/device_1.rs
@@ -22,7 +22,5 @@ pub fn test_output_device_from_other_xremap_process_is_grabbed() -> Result<()> {
         .ignore_device(devices_at_test_start)
         .build()?;
 
-    ctrl.raw_kill()?;
-
-    Ok(())
+    ctrl.kill()
 }

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -46,7 +46,7 @@ pub fn e2e_old_config_remains_active_when_error() -> anyhow::Result<()> {
             "})?
         .build()?;
 
-    std::fs::write(&ctrl.get_config_file(), "failed_config")?;
+    std::fs::write(&ctrl.get_config_file(), "partial_config")?;
 
     std::thread::sleep(std::time::Duration::from_millis(20));
 
@@ -96,7 +96,7 @@ pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
         .build()?;
 
     std::fs::write(&ctrl.get_config_file(), "")?;
-    std::fs::write(&ctrl.get_config_file(), "failed_config")?;
+    std::fs::write(&ctrl.get_config_file(), "partial_config")?;
     std::fs::write(&ctrl.get_config_file(), "")?;
     std::fs::write(&ctrl.get_config_file(), "other problem")?;
     std::fs::write(
@@ -134,9 +134,12 @@ pub fn e2e_config_watch_with_notifications() -> anyhow::Result<()> {
             config_watch_debounce_ms: 10
         "};
 
-    let mut ctrl = XremapController::builder().watch_config(config)?.build()?;
+    let mut ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
+        .watch_config(config)?
+        .build()?;
 
-    std::fs::write(&ctrl.get_config_file(), "failed_config")?;
+    std::fs::write(&ctrl.get_config_file(), "partial_config")?;
 
     std::thread::sleep(std::time::Duration::from_millis(20));
 

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -54,7 +54,10 @@ pub fn e2e_disconnecting_device_in_watch_mode() -> anyhow::Result<()> {
 
     let output = ctrl.kill_for_output()?;
 
-    assert_str_contains("Found a removed device. Reselecting devices.", &output.stdout);
+    assert_str_contains(
+        &format!("Found a removed device: \"{}\"", ctrl.get_input_device_name().as_ref().unwrap()),
+        &output.stdout,
+    );
 
     Ok(())
 }
@@ -84,7 +87,11 @@ pub fn e2e_disconnecting_two_devices_in_watch_mode() -> anyhow::Result<()> {
 
     let output = ctrl.kill_for_output()?;
 
-    assert!(output.stdout.contains("Found a removed device. Reselecting devices."));
+    assert!(output.stdout.contains(&format!("Found a removed device: \"{}\"", name)));
+
+    assert!(output
+        .stdout
+        .contains(&format!("Found a removed device: \"{}\"", name2)));
 
     Ok(())
 }

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -35,7 +35,7 @@ pub fn e2e_connecting_device_in_watch_mode() -> anyhow::Result<()> {
 
     let output = ctrl.kill_for_output()?;
 
-    assert_str_contains("warning: No device was selected, but --watch is waiting for new devices.", &output.stdout);
+    assert_str_contains("No device was selected, but --watch is waiting for new devices.", &output.stdout);
     // A poor test, that device is now selected.
     assert_str_contains(&format!(": {}", name), &output.stdout);
 

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -1,7 +1,11 @@
 #![cfg(feature = "device-test")]
 
 use crate::common::xremap_controller::{InputDeviceFilter, XremapController};
-use crate::common::{assert_str_contains, get_random_device_name, get_virtual_device};
+use crate::common::{
+    assert_str_contains, get_random_device_name, get_virtual_device, get_virtual_device_without_wait, key_press,
+};
+use evdev::KeyCode as Key;
+use std::time::Duration;
 
 mod common;
 
@@ -122,4 +126,28 @@ pub fn e2e_disconnecting_two_devices_in_watch_mode() -> anyhow::Result<()> {
         .contains(&format!("Found a removed device: \"{}\"", name2)));
 
     Ok(())
+}
+
+#[test]
+pub fn e2e_fast_connect_and_disconnect_in_watch_mode() -> anyhow::Result<()> {
+    let name = get_random_device_name();
+    let ctrl = XremapController::builder()
+        .input_device(InputDeviceFilter::CustomFilter { filter: name.clone() })
+        .watch(true)
+        .build()?;
+
+    let mut device = get_virtual_device_without_wait(&name)?;
+    // Make xremap spend more time in the race-condition
+    // region from InputDevice::try_from() to device.grab()
+    device.emit(&[key_press(Key::BTN_TRIGGER_HAPPY1)])?;
+
+    // Allow xremap to go into wait-for-keys-loop
+    std::thread::sleep(Duration::from_millis(100));
+
+    // Force an ENODEV error, that must not be printed by xremap
+    drop(device);
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    ctrl.kill()
 }

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -43,6 +43,34 @@ pub fn e2e_connecting_device_in_watch_mode() -> anyhow::Result<()> {
 }
 
 #[test]
+pub fn e2e_connecting_two_devices_in_watch_mode() -> anyhow::Result<()> {
+    let name = get_random_device_name();
+    let name2 = format!("{name} 2");
+
+    let mut ctrl = XremapController::builder()
+        .input_device(InputDeviceFilter::CustomFilter { filter: name.clone() })
+        .watch(true)
+        .build()?;
+
+    // Reveals a race-condition
+    ctrl.open_input_device(&name)?;
+
+    let _dev1 = get_virtual_device(&name)?;
+    let _dev2 = get_virtual_device(&name2)?;
+
+    // Give time to handle the event, otherwise it's a race-condition whether
+    //  kill or handling-disconnect happens first.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let output = ctrl.kill_for_output()?;
+
+    assert_str_contains(&format!(": {}", name), &output.stdout);
+    assert_str_contains(&format!(": {}", name2), &output.stdout);
+
+    Ok(())
+}
+
+#[test]
 pub fn e2e_disconnecting_device_in_watch_mode() -> anyhow::Result<()> {
     let mut ctrl = XremapController::builder().watch(true).build()?;
 


### PR DESCRIPTION
Device watching had some problems with both race-condititions and sensitivity to the expectable unpredictable batching and duplicate file events.

The important commits:
* Ignore irrelevant device events
  - Ignore file events for devices that are already grabbed, those would cause EBUSY when trying to regrab a device. 
  - Ignore multiple file events for the same device in same batch.
* Only remove a single device, when events can't be fetched.
  - Instead of ungrabbing all devices, when it's detected one is removed. Only that specific device is removed. This fixes the case where two devices are removed, and it's tried to regrab the second removed device. It's better to react on the information that is certain instead of regrabbing all devices.
* Fix race from InputDevice::try_from() to device.grab()
   - There is no way to atomically grab a device. When reading `/dev/input` folder, anything can happen in the time until `device.grab()` is called. The only solution is therefore to squash `ENODEV` errors when grabbing. Note that `InputDevice::try_from()` already squashes all errors.


**Problems that still remain**

`evdev` prints an error message, if the device can't be ungrabbed, even though the device is gone, and ungrab is not needed. [I have made a PR that is still open.](https://github.com/emberian/evdev/pull/172)

The error message is "Failed to ungrab device: No such device (os error 19)"


