### PR TITLE
Fix: non deterministic inexact match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -921,12 +921,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1511,7 +1511,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -1538,7 +1538,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -1685,7 +1685,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -1718,7 +1718,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.14",
@@ -1920,7 +1920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1933,7 +1933,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -2280,7 +2280,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2311,7 +2311,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2330,7 +2330,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -2381,6 +2381,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hyprland",
+ "indexmap 2.14.0",
  "indoc",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ wayland-protocols = { version = "0.32.10", features = ["client"], optional = tru
 wayland-scanner = { version = "0.31.10", optional = true }
 wayland-backend = { version = "0.3.12", optional = true }
 tokio = { version = "1.49.0", optional = true, features = ["full"] }
+indexmap = { version = "2.14.0", features = ["serde"] }
 
 [dev-dependencies]
 fastrand = "2.3.0"

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -5,6 +5,7 @@ use crate::config::application::OnlyOrNot;
 use crate::config::key_press::KeyPress;
 use crate::config::keymap_action::{Actions, KeymapAction};
 use evdev::KeyCode as Key;
+use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 
@@ -16,7 +17,7 @@ pub struct Keymap {
     #[serde(default = "String::new")]
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]
-    pub remap: HashMap<KeyPress, Vec<KeymapAction>>,
+    pub remap: IndexMap<KeyPress, Vec<KeymapAction>>,
     pub application: Option<OnlyOrNot>,
     pub window: Option<OnlyOrNot>,
     pub device: Option<DeviceMatcher>,
@@ -26,11 +27,12 @@ pub struct Keymap {
     pub exact_match: bool,
 }
 
-fn deserialize_remap<'de, D>(deserializer: D) -> Result<HashMap<KeyPress, Vec<KeymapAction>>, D::Error>
+fn deserialize_remap<'de, D>(deserializer: D) -> Result<IndexMap<KeyPress, Vec<KeymapAction>>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let remap = HashMap::<KeyPress, Actions>::deserialize(deserializer)?;
+    // IndexMap preserves the order from the config file, which is why it's used instead of HashMap.
+    let remap = IndexMap::<KeyPress, Actions>::deserialize(deserializer)?;
     Ok(remap
         .into_iter()
         .map(|(key_press, actions)| (key_press, actions.into_vec()))
@@ -88,7 +90,7 @@ pub struct OverrideEntry {
 
 // This is executed on runtime unlike build_keymap_table, but hopefully not called so often.
 pub fn build_override_table(
-    remap: &HashMap<KeyPress, Vec<KeymapAction>>,
+    remap: &IndexMap<KeyPress, Vec<KeymapAction>>,
     exact_match: bool,
 ) -> HashMap<Key, Vec<OverrideEntry>> {
     let mut table: HashMap<Key, Vec<OverrideEntry>> = HashMap::new();

--- a/src/config/nested_remap.rs
+++ b/src/config/nested_remap.rs
@@ -1,16 +1,15 @@
-use super::keymap_action::Actions;
 use crate::config::application::deserialize_string_or_vec;
 use crate::config::key::parse_key;
 use crate::config::key_press::KeyPress;
-use crate::config::keymap_action::KeymapAction;
+use crate::config::keymap_action::{Actions, KeymapAction};
 use evdev::KeyCode as Key;
+use indexmap::IndexMap;
 use serde::{de, Deserialize, Deserializer};
-use std::collections::HashMap;
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
 pub struct Remap {
-    pub remap: HashMap<KeyPress, Vec<KeymapAction>>,
+    pub remap: IndexMap<KeyPress, Vec<KeymapAction>>,
     pub timeout: Option<Duration>,
     pub timeout_key: Option<Vec<Key>>,
 }
@@ -18,7 +17,7 @@ pub struct Remap {
 // Used only for deserialization
 #[derive(Debug, Deserialize)]
 pub struct RemapActions {
-    pub remap: HashMap<KeyPress, Actions>,
+    pub remap: IndexMap<KeyPress, Actions>,
     pub timeout_millis: Option<u64>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub timeout_key: Option<Vec<String>>,

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -5,7 +5,7 @@ use crate::config::Config;
 use crate::event_handler::{DISGUISED_EVENT_OFFSETTER, KEY_MATCH_ANY};
 use anyhow::bail;
 use evdev::KeyCode as Key;
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 pub fn validate_config_file(config: &Config) -> anyhow::Result<()> {
     for modmap in &config.modmap {
@@ -68,7 +68,7 @@ fn traverse_modmap_operator(operator: &ModmapOperator) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn traverse_remap(keymap: &HashMap<KeyPress, Vec<KeymapAction>>) -> anyhow::Result<()> {
+fn traverse_remap(keymap: &IndexMap<KeyPress, Vec<KeymapAction>>) -> anyhow::Result<()> {
     for (_, actions) in keymap {
         traverse_actions(actions)?;
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -183,6 +183,63 @@ fn test_exact_match_default() {
 }
 
 #[test]
+fn test_keymap_inexact_when_union_of_modifiers() {
+    // First is used when both match
+    assert_actions(
+        indoc! {"
+        keymap:
+            - remap:
+                alt-W: A
+                control-W: B
+        "},
+        vec![
+            Event::key_press(Key::KEY_LEFTALT),
+            Event::key_press(Key::KEY_LEFTCTRL),
+            Event::key_press(Key::KEY_W),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}
+
+#[test]
+fn test_keymap_matches_exact_before_inexact() {
+    assert_actions(
+        indoc! {"
+        keymap:
+            - remap:
+                control-W: B
+                control-shift-W: A
+        "},
+        vec![
+            Event::key_press(Key::KEY_LEFTSHIFT),
+            Event::key_press(Key::KEY_LEFTCTRL),
+            Event::key_press(Key::KEY_W),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}
+
+#[test]
 fn test_keymaps_are_merged() {
     assert_actions(
         indoc! {"

--- a/src/tests_nested_remap.rs
+++ b/src/tests_nested_remap.rs
@@ -628,3 +628,34 @@ fn test_mixing_no_keypress_and_remap_in_keymap_action() {
         ],
     )
 }
+
+#[test]
+fn test_nested_remap_inexact_when_union_of_modifiers() {
+    // First is used when both match
+    assert_actions(
+        indoc! {"
+        keymap:
+            - remap:
+                c-x:
+                  remap:
+                    alt-W: A
+                    control-W: B
+        "},
+        vec![
+            Event::key_press(Key::KEY_LEFTALT),
+            Event::key_press(Key::KEY_LEFTCTRL),
+            Event::key_press(Key::KEY_X),
+            Event::key_press(Key::KEY_W),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}


### PR DESCRIPTION
When using inexact match in keymap or nested keymap there is the possibility that more than one remap matches. That happens when the union of the remaps' modifiers are pressed. Because then will each remap have its modifiers pressed, and they accept the extra modifiers.

This becomes non-deterministic because the configuration is read into a `HashMap`. The user rightfully expect the first remap to be deterministically used when multiple match. Which is achieved by using `IndexedMap` instead.

It doesn't break anything because users could previous tolerate both choices, so picking one won't break users. IndexedMap isn't used for anything but parsing because it's processed to `HashMap` in `build_keymap_table` and `build_override_table`, so performance couldn't change at all.

Possible fix for #615