### PR TITLE
refactor: Remove futures crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,46 +675,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -747,12 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,13 +722,9 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -2378,7 +2332,6 @@ dependencies = [
  "evdev",
  "fastrand",
  "fork",
- "futures",
  "futures-util",
  "hyprland",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ zbus = { version = "5.14.0", optional = true }
 hyprland = { version = "0.4.0-beta.3", optional = true }
 toml = "1.1.2"
 udev = { version = "0.9.3", optional = true }
-futures = "0.3.32"
 wayland-protocols = { version = "0.32.10", features = ["client"], optional = true }
 wayland-scanner = { version = "0.31.10", optional = true }
 wayland-backend = { version = "0.3.12", optional = true }

--- a/src/client/gnome_client.rs
+++ b/src/client/gnome_client.rs
@@ -1,12 +1,11 @@
 use crate::bridge::ActiveWindow;
 use crate::client::{Client, WindowInfo};
 use anyhow::bail;
-use futures::executor::block_on;
 use log::debug;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use zbus::{zvariant, Connection, Error, Message};
+use zbus::{block_on, zvariant, Connection, Error, Message};
 
 pub struct GnomeClient {
     socket_path: Option<String>,

--- a/src/client/kde/adhoc_script_handler.rs
+++ b/src/client/kde/adhoc_script_handler.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
-use futures::executor::block_on;
 use std::env::temp_dir;
 use std::path::Path;
-use zbus::Connection;
+use zbus::{block_on, Connection};
 
 pub struct AdhocScriptHandler {}
 

--- a/src/client/kde/kde_client.rs
+++ b/src/client/kde/kde_client.rs
@@ -2,14 +2,13 @@ use crate::client::kde::kwin_scripts::KwinScripts;
 use crate::client::kde::plugin_script_handler::ensure_script_loaded;
 use crate::client::{Client, WindowInfo};
 use anyhow::{bail, Result};
-use futures::executor::block_on;
 use log::{debug, error, warn};
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use zbus::connection::Builder;
-use zbus::{interface, Connection};
+use zbus::{block_on, interface, Connection};
 
 pub const KWIN_SCRIPT: &str = include_str!("kwin-script.js");
 pub const KWIN_SCRIPT_PLUGIN_NAME: &str = "xremap";

--- a/src/client/kde/plugin_script_handler.rs
+++ b/src/client/kde/plugin_script_handler.rs
@@ -1,10 +1,9 @@
 use crate::client::kde::kde_client::{KWIN_SCRIPT, KWIN_SCRIPT_PLUGIN_NAME};
 use anyhow::Result;
-use futures::executor::block_on;
 use log::debug;
 use std::env::temp_dir;
 use std::path::{Path, PathBuf};
-use zbus::Connection;
+use zbus::{block_on, Connection};
 
 struct KwinScriptTempFile(PathBuf);
 


### PR DESCRIPTION
`zbus` exports a `block_on` function, so there is no need for the `futures` crate.