### PR TITLE
refactor: Remove tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,15 +986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,29 +1103,6 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "pastey"
@@ -1265,15 +1233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,12 +1338,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1613,12 +1566,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -2345,7 +2295,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "tokio",
  "toml",
  "udev",
  "wayland-backend",
@@ -2382,7 +2331,6 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
- "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ udev = { version = "0.9.3", optional = true }
 wayland-protocols = { version = "0.32.10", features = ["client"], optional = true }
 wayland-scanner = { version = "0.31.10", optional = true }
 wayland-backend = { version = "0.3.12", optional = true }
-tokio = { version = "1.49.0", optional = true, features = ["full"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
 
 [dev-dependencies]
@@ -52,7 +51,7 @@ udev = ["dep:udev"]
 niri = ["niri-ipc"]
 device-test = []
 cosmic = [ "wayland-client","wayland-scanner","wayland-backend"]
-socket = ["futures-util", "tokio", "zbus", "zbus/tokio"]
+socket = ["futures-util", "zbus"]
 
 [profile.release]
 codegen-units = 1

--- a/src/client/socket_client.rs
+++ b/src/client/socket_client.rs
@@ -1,6 +1,5 @@
 use super::socket_monitor::SessionMonitor;
-use crate::bridge::ActiveWindow;
-use crate::bridge::{Request, Response};
+use crate::bridge::{ActiveWindow, Request, Response};
 use crate::client::{Client, WindowInfo};
 use anyhow::{anyhow, bail, Context, Result};
 use log::debug;
@@ -9,8 +8,8 @@ use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::sync::Arc;
+use std::thread::spawn;
 use std::time::Duration;
-use tokio::runtime::{Builder, Runtime};
 
 // This client supports a line-based socket protocol where a message is
 // sent over the socket as a single line of JSON followed by a newline ('\n'),
@@ -32,7 +31,6 @@ const XREMAP_SOCKET: &str = "/run/xremap/{uid}/xremap.sock";
 pub struct SocketClient {
     socket_path: String,
     monitor: Arc<SessionMonitor>,
-    _runtime: Runtime,
 }
 
 impl SocketClient {
@@ -40,17 +38,9 @@ impl SocketClient {
         let socket_path = std::env::var("XREMAP_SOCKET").unwrap_or(XREMAP_SOCKET.to_string());
         let monitor = Arc::new(SessionMonitor::new(socket_path.clone()));
         let monitor_ = monitor.clone();
-        let runtime = Builder::new_multi_thread()
-            .worker_threads(1)
-            .enable_all()
-            .build()
-            .unwrap();
-        runtime.spawn(async move { monitor_.run().await });
-        SocketClient {
-            socket_path,
-            monitor,
-            _runtime: runtime,
-        }
+        let _handle = spawn(move || monitor_.run());
+
+        SocketClient { socket_path, monitor }
     }
 
     fn get_active_window(&self) -> Result<ActiveWindow> {

--- a/src/client/socket_monitor.rs
+++ b/src/client/socket_monitor.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use zbus::fdo::DBusProxy;
 use zbus::zvariant::{OwnedObjectPath, Value};
-use zbus::{Connection, MatchRule, Message, MessageStream};
+use zbus::{block_on, Connection, MatchRule, Message, MessageStream};
 
 pub struct SessionMonitor {
     socket_path: String,
@@ -29,7 +29,7 @@ impl SessionMonitor {
         self.sessions.lock().unwrap().get_active_session()
     }
 
-    pub async fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
         let session_new_rule = MatchRule::builder()
             .msg_type(zbus::message::Type::Signal)
             .interface("org.freedesktop.login1.Manager")?
@@ -40,22 +40,23 @@ impl SessionMonitor {
             .interface("org.freedesktop.login1.Manager")?
             .member("SessionRemoved")?
             .build();
-        let connection = Connection::system().await?;
-        let proxy = DBusProxy::new(&connection).await?;
+        let connection = block_on(Connection::system())?;
+        let proxy = block_on(DBusProxy::new(&connection))?;
         let connection = self.connection.get_or_init(|| connection);
         let proxy = self.proxy.get_or_init(|| proxy);
 
-        proxy.add_match_rule(session_new_rule).await?;
-        proxy.add_match_rule(session_removed_rule).await?;
+        block_on(proxy.add_match_rule(session_new_rule))?;
+        block_on(proxy.add_match_rule(session_removed_rule))?;
 
         debug!("Monitoring user sessions...");
-        if let Err(why) = self.monitor_existing_sessions().await {
+        if let Err(why) = self.monitor_existing_sessions() {
             warn!("Cannot monitor existing sessions: {}", why)
         };
-        while let Some(msg) = MessageStream::from(connection).next().await {
+        let mut stream = MessageStream::from(connection);
+        while let Some(msg) = block_on(stream.next()) {
             match msg {
                 Ok(message) => {
-                    if let Err(handle_err) = self.handle_message(&message).await {
+                    if let Err(handle_err) = self.handle_message(&message) {
                         warn!("Could not handle {:?}: {}", message, handle_err)
                     }
                 }
@@ -65,7 +66,7 @@ impl SessionMonitor {
         Ok(())
     }
 
-    async fn handle_message(&self, message: &Message) -> Result<()> {
+    fn handle_message(&self, message: &Message) -> Result<()> {
         let header = message.header();
         let member = match header.member() {
             Some(m) => m,
@@ -74,7 +75,7 @@ impl SessionMonitor {
         match member.as_str() {
             "SessionNew" => {
                 let (session_id, session_path): (String, OwnedObjectPath) = message.body().deserialize()?;
-                self.handle_new_session(&session_id, &session_path).await?;
+                self.handle_new_session(&session_id, &session_path)?;
             }
             "PropertiesChanged" => {
                 let header = message.header();
@@ -83,13 +84,13 @@ impl SessionMonitor {
                 let body = message.body();
                 let (_name, changed, _invalidated): (String, HashMap<String, Value<'_>>, Vec<String>) =
                     body.deserialize()?;
-                self.handle_properties_changed(session_path, changed).await;
+                self.handle_properties_changed(session_path, changed);
             }
             "SessionRemoved" => {
                 let (session_id, session_path): (String, OwnedObjectPath) = message.body().deserialize()?;
                 let (session, active) = self.sessions.lock().unwrap().remove(&session_path);
                 if session.is_some() || active.is_some() {
-                    self.remove_properties_changed_match_rule(&session_path).await?;
+                    self.remove_properties_changed_match_rule(&session_path)?;
                     if session.is_some() {
                         info!("Removed session {}", session_id);
                     } else if active.is_some() {
@@ -102,23 +103,23 @@ impl SessionMonitor {
         Ok(())
     }
 
-    async fn handle_new_session(&self, session_id: &String, session_path: &OwnedObjectPath) -> Result<()> {
+    fn handle_new_session(&self, session_id: &String, session_path: &OwnedObjectPath) -> Result<()> {
         let connection = self.connection.get().ok_or(anyhow!("not connected"))?;
-        let session_proxy = SessionProxy::builder(&connection).path(session_path)?.build().await?;
-        let (seat_id, _seat_path) = session_proxy.seat().await?;
+        let session_proxy = block_on(SessionProxy::builder(&connection).path(session_path)?.build())?;
+        let (seat_id, _seat_path) = block_on(session_proxy.seat())?;
         if seat_id.is_empty() {
             debug!("Ignoring unseated session {}", session_id);
             return Ok(());
         }
-        let (uid, _user_path) = session_proxy.user().await?;
-        let is_active = session_proxy.active().await?;
+        let (uid, _user_path) = block_on(session_proxy.user())?;
+        let is_active = block_on(session_proxy.active())?;
         let session = Session {
             id: session_id.clone(),
             user_socket: user_socket_path(&self.socket_path, uid),
         };
         let active_str = if is_active { " active" } else { "" };
         info!("Monitoring{} session {} (uid={}, seat={})", active_str, session_id, uid, seat_id);
-        self.add_properties_changed_match_rule(&session_path).await?;
+        self.add_properties_changed_match_rule(&session_path)?;
         self.sessions
             .lock()
             .unwrap()
@@ -126,7 +127,7 @@ impl SessionMonitor {
         Ok(())
     }
 
-    async fn handle_properties_changed(&self, session_path: OwnedObjectPath, changed: HashMap<String, Value<'_>>) {
+    fn handle_properties_changed(&self, session_path: OwnedObjectPath, changed: HashMap<String, Value<'_>>) {
         if let Some(Value::Bool(is_active)) = changed.get("Active") {
             let mut sessions = self.sessions.lock().unwrap();
             if *is_active {
@@ -141,17 +142,17 @@ impl SessionMonitor {
         }
     }
 
-    async fn monitor_existing_sessions(&self) -> Result<()> {
+    fn monitor_existing_sessions(&self) -> Result<()> {
         let connection = self.connection.get().ok_or(anyhow!("not connected"))?;
-        let manager = ManagerProxy::new(&connection).await?;
-        let session_list = manager.list_sessions().await?;
+        let manager = block_on(ManagerProxy::new(&connection))?;
+        let session_list = block_on(manager.list_sessions())?;
         for (session_id, uid, _user, seat_id, session_path) in session_list {
             if seat_id.is_empty() {
                 continue;
             }
             info!("Existing session: {} (uid={}, seat={})", session_id, uid, seat_id);
-            let session_proxy = SessionProxy::builder(&connection).path(&session_path)?.build().await?;
-            let is_active = session_proxy.active().await?;
+            let session_proxy = block_on(SessionProxy::builder(&connection).path(&session_path)?.build())?;
+            let is_active = block_on(session_proxy.active())?;
             let session = Session {
                 id: session_id.clone(),
                 user_socket: user_socket_path(&self.socket_path, uid),
@@ -160,21 +161,21 @@ impl SessionMonitor {
                 .lock()
                 .unwrap()
                 .insert(session_path.clone(), session, is_active);
-            self.add_properties_changed_match_rule(&session_path).await?
+            self.add_properties_changed_match_rule(&session_path)?;
         }
         Ok(())
     }
 
-    async fn add_properties_changed_match_rule(&self, session_path: &OwnedObjectPath) -> Result<()> {
+    fn add_properties_changed_match_rule(&self, session_path: &OwnedObjectPath) -> Result<()> {
         let proxy = self.proxy.get().ok_or(anyhow!("not connected"))?;
         let rule = session_changed_rule(session_path)?;
-        Ok(proxy.add_match_rule(rule).await?)
+        Ok(block_on(proxy.add_match_rule(rule))?)
     }
 
-    async fn remove_properties_changed_match_rule(&self, session_path: &OwnedObjectPath) -> Result<()> {
+    fn remove_properties_changed_match_rule(&self, session_path: &OwnedObjectPath) -> Result<()> {
         let proxy = self.proxy.get().ok_or(anyhow!("not connected"))?;
         let rule = session_changed_rule(session_path)?;
-        Ok(proxy.remove_match_rule(rule).await?)
+        Ok(block_on(proxy.remove_match_rule(rule))?)
     }
 }
 


### PR DESCRIPTION
`tokio` is only used in the `socket` feature. But that's not necessary, because all futures are awaited for, meaning the execution is serial. So `block_on` does the same thing.

This saves one dependency, but it also opens up for compiling the `socket` feature with other features, which is currently not possible. `zbus` does a magic macro thing when its `tokio` features is used, which means KDE and GNOME clients break if compiled the `socket`