### PR TITLE
Fix: Keep compat for change to KDE Kwin script.

### DIFF
--- a/src/client/kde/kde_client.rs
+++ b/src/client/kde/kde_client.rs
@@ -137,7 +137,16 @@ struct DbusServerInterface {
 
 #[interface(name = "com.k0kubun.Xremap")]
 impl DbusServerInterface {
-    fn notify_active_window(&self, title: String, res_class: String) {
+    /// Old KWin scripts are only reloaded after relogin, which means they remain active
+    /// when updating the xremap binary. To avoid errors due to change of API. This
+    /// method can change name so only the old script calls this method.
+    /// There're two places the method call (NotifyActiveWindow) must be changed.
+    fn notify_active_window(&self, title: String, res_class: String, _res_name: String) {
+        println!("Restart or relogin is needed to finish update and make KDE integration work fully.");
+        self.notify_active_window2(title, res_class)
+    }
+
+    fn notify_active_window2(&self, title: String, res_class: String) {
         // Print when log_window_changes is enabled to help identify application resource classes.
         if self.log_window_changes {
             println!("active window: caption: '{title}', class: '{res_class}'");

--- a/src/client/kde/kwin-script.js
+++ b/src/client/kde/kwin-script.js
@@ -7,7 +7,7 @@ function notifyActiveWindow(client) {
         "com.k0kubun.Xremap",
         "/com/k0kubun/Xremap",
         "com.k0kubun.Xremap",
-        "NotifyActiveWindow",
+        "NotifyActiveWindow2",
         "caption" in client ? client.caption : "",
         "resourceClass" in client ? client.resourceClass : "",
     );

--- a/src/client/kde/kwin_scripts.rs
+++ b/src/client/kde/kwin_scripts.rs
@@ -51,7 +51,7 @@ function notifyActiveWindow(client) {
         "com.k0kubun.Xremap",
         "/com/k0kubun/Xremap",
         "com.k0kubun.Xremap",
-        "NotifyActiveWindow",
+        "NotifyActiveWindow2",
         "caption" in client ? client.caption : "",
         "resourceClass" in client ? client.resourceClass : ""
     );


### PR DESCRIPTION
Old KWin scripts are only reloaded after relogin, which means they remain active when updating the xremap binary. To avoid errors due to change of DBus server API, the old method in the DBus server is preserved, so it can print an error message until the new KWin script is reloaded.

This fixes errors like #908, but it doesn't work for `v0.15.3` and `v0.15.4`. Because the API for `v0.15.2` is chosen, because most users must be on that or earlier versions.