### PR TITLE
Add support for Pantheon Wayland

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
-        feature: [x11, gnome, kde, hypr, wlroots, niri, cosmic, socket]
+        feature:
+          [x11, gnome, kde, hypr, wlroots, niri, cosmic, pantheon, socket]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -108,6 +109,8 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with: { name: xremap-x86_64-cosmic, path: package/ }
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with: { name: xremap-x86_64-pantheon, path: package/ }
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with: { name: xremap-x86_64-socket, path: package/ }
 
       # Fetch aarch64 binary
@@ -125,6 +128,8 @@ jobs:
         with: { name: xremap-aarch64-niri, path: package/ }
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with: { name: xremap-aarch64-cosmic, path: package/ }
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with: { name: xremap-aarch64-pantheon, path: package/ }
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with: { name: xremap-aarch64-socket, path: package/ }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ niri = ["niri-ipc"]
 device-test = []
 cosmic = [ "wayland-client","wayland-scanner","wayland-backend"]
 socket = ["futures-util", "zbus"]
+pantheon = ["zbus"]
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -47,15 +47,16 @@ If it doesn't work, please [install Rust](https://doc.rust-lang.org/cargo/gettin
 and run one of the following commands:
 
 ```bash
-cargo install xremap --features x11     # X11
-cargo install xremap --features gnome   # GNOME Wayland
-cargo install xremap --features kde     # KDE-Plasma Wayland
-cargo install xremap --features wlroots # Sway, Wayfire, etc.
-cargo install xremap --features hypr    # Hyprland
-cargo install xremap --features niri    # Niri
-cargo install xremap --features cosmic  # COSMIC Wayland
-cargo install xremap --features socket  # Variant for system service
-cargo install xremap                    # Others
+cargo install xremap --features x11      # X11
+cargo install xremap --features gnome    # GNOME Wayland
+cargo install xremap --features kde      # KDE-Plasma Wayland
+cargo install xremap --features wlroots  # Sway, Wayfire, etc.
+cargo install xremap --features hypr     # Hyprland
+cargo install xremap --features niri     # Niri
+cargo install xremap --features cosmic   # COSMIC Wayland
+cargo install xremap --features pantheon # Pantheon Wayland (aka Secure)
+cargo install xremap --features socket   # Variant for system service
+cargo install xremap                     # Others
 ```
 
 You may also need to install `libx11-dev` to run `xremap` for X11.
@@ -661,7 +662,7 @@ xremap --device "first device" --device "second device" config.yml
 - @N4tus (KDE client)
 - @jixiuf (wlroots client)
 - @saurabhsharan (Niri client)
-- @hpccc53 (Cosmic client)
+- @hpccc53 (COSMIC, Pantheon client)
 
 ## Releasing
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,6 +14,8 @@ mod hypr_client;
 mod kde;
 #[cfg(feature = "niri")]
 mod niri_client;
+#[cfg(feature = "pantheon")]
+mod pantheon_client;
 #[cfg(feature = "socket")]
 mod socket_client;
 #[cfg(feature = "socket")]
@@ -143,6 +145,8 @@ pub fn build_client(log_window_changes: bool) -> WMClient {
         WMClient::new("Niri", Box::new(niri_client::NiriClient::new()), log_window_changes),
         #[cfg(feature = "cosmic")]
         WMClient::new("COSMIC", Box::new(cosmic_client::CosmicClient::new()), log_window_changes),
+        #[cfg(feature = "pantheon")]
+        WMClient::new("Pantheon", Box::new(pantheon_client::PantheonClient::new()), log_window_changes),
         #[cfg(feature = "socket")]
         WMClient::new("Socket", Box::new(socket_client::SocketClient::new()), log_window_changes),
         #[cfg(feature = "device-test")]

--- a/src/client/pantheon_client.rs
+++ b/src/client/pantheon_client.rs
@@ -1,0 +1,106 @@
+use crate::client::{Client, WindowInfo};
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+use zbus::zvariant::Value;
+use zbus::{block_on, Connection};
+
+#[derive(Debug)]
+struct PantheonWindow {
+    id: String,
+    app_class: Option<String>,
+    title: Option<String>,
+    focused: bool,
+}
+
+pub struct PantheonClient {
+    connection: Option<Connection>,
+}
+
+impl PantheonClient {
+    pub fn new() -> Self {
+        Self { connection: None }
+    }
+
+    fn connect(&mut self) -> Result<&mut Connection> {
+        if self.connection.is_none() {
+            self.connection = Some(block_on(Connection::session())?);
+        }
+
+        Ok(self
+            .connection
+            .as_mut()
+            .ok_or_else(|| anyhow::format_err!("This cannot happen"))?)
+    }
+
+    fn get_focused_window(&mut self) -> Result<Option<PantheonWindow>> {
+        Ok(self.get_windows()?.into_iter().find(|window| window.focused))
+    }
+
+    fn get_windows(&mut self) -> Result<Vec<PantheonWindow>> {
+        let body = block_on(self.connect()?.call_method(
+            Some("org.pantheon.gala"),
+            "/org/pantheon/gala/DesktopInterface",
+            Some("org.pantheon.gala.DesktopIntegration"),
+            "GetWindows",
+            &(),
+        ))?
+        .body();
+
+        Ok(body
+            .deserialize::<Vec<(u64, HashMap<String, Value>)>>()?
+            .into_iter()
+            .map(|(id, dict)| PantheonWindow {
+                id: format!("{id}"),
+                title: dict.get("title").map(|v| String::try_from(v).unwrap_or_default()),
+                app_class: dict.get("wm-class").map(|v| String::try_from(v).unwrap_or_default()),
+                focused: dict
+                    .get("has-focus")
+                    .map(|v| bool::try_from(v))
+                    .unwrap_or(Ok(false))
+                    .unwrap_or_default(),
+            })
+            .collect())
+    }
+}
+
+impl Client for PantheonClient {
+    fn supported(&mut self) -> bool {
+        self.get_windows().is_ok()
+    }
+
+    fn current_window(&mut self) -> Option<String> {
+        match self.get_focused_window() {
+            Ok(window) => window.and_then(|window| window.title),
+            Err(e) => {
+                eprintln!("Error when fetching window title: {e:?}");
+                None
+            }
+        }
+    }
+
+    fn current_application(&mut self) -> Option<String> {
+        match self.get_focused_window() {
+            Ok(window) => window.and_then(|window| window.app_class),
+            Err(e) => {
+                eprintln!("Error when fetching app_class: {e:?}");
+                None
+            }
+        }
+    }
+
+    fn window_list(&mut self) -> Result<Vec<WindowInfo>> {
+        Ok(self
+            .get_windows()?
+            .into_iter()
+            .map(|window| WindowInfo {
+                winid: Some(window.id),
+                app_class: window.app_class,
+                title: window.title,
+            })
+            .collect())
+    }
+
+    fn close_windows_by_app_class(&mut self, _app_class: &str) -> Result<()> {
+        bail!("close_windows_by_app_class not implemented for Pantheon")
+    }
+}


### PR DESCRIPTION
Add application-specific remapping support for Pantheon desktop environment using its DBus API. Useful when using ElementaryOS with a Wayland session, which doesn't supply any of the usual toplevel protocols.

`close_apps` isn't implemented, because an API for that was not found.