### PR TITLE
Add application-specific remapping to experimental_map

### DIFF
--- a/doc/reference_chords.md
+++ b/doc/reference_chords.md
@@ -2,10 +2,12 @@
 
 ### Experimental
 
-Experimental means this feature is likely to change in the feature as it's improved. This
-can break configuration files in any version update of xremap.
+Experimental means this feature is likely to change in the future as it's improved. This
+can break configuration files in any version update of xremap, and will be noted in CHANGELOG.md.
 
-Features available in `modmap` like: `application`, `window`, `device`, `mode` doesn't work in `experimental_map`.
+Features available in `modmap` like: `device`, `mode`, key-to-key mapping,
+multi-purpose key and press/release key don't work in `experimental_map`.
+But application-specific remapping with `application` and `window` works since `v0.15.5`.
 
 ### Example
 

--- a/doc/reference_double_tap.md
+++ b/doc/reference_double_tap.md
@@ -2,10 +2,12 @@
 
 ### Experimental
 
-Experimental means this feature is likely to change in the feature as it's improved. This
-can break configuration files in any version update of xremap.
+Experimental means this feature is likely to change in the future as it's improved. This
+can break configuration files in any version update of xremap, and will be noted in CHANGELOG.md.
 
-Features available in `modmap` like: `application`, `window`, `device`, `mode` doesn't work in `experimental_map`.
+Features available in `modmap` like: `device`, `mode`, key-to-key mapping,
+multi-purpose key and press/release key don't work in `experimental_map`.
+But application-specific remapping with `application` and `window` works since `v0.15.5`.
 
 ### Example
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,4 @@
+use crate::config::application::OnlyOrNot;
 use crate::util::print_table;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -54,10 +55,18 @@ pub trait Client {
 pub struct WMClient {
     pub name: String,
     pub client: Box<dyn Client>,
+    // Cached value of calling `client.supported()`
     supported: Option<bool>,
+    // The last app_class logged to console
     last_application: String,
+    // The last title logged to console
     last_window: String,
+    // Log app_class and window changes to console.
     log_window_changes: bool,
+    // Cache to reduce use of clients.
+    application_cache: Option<String>,
+    // Cache to reduce use of clients.
+    title_cache: Option<String>,
 }
 
 impl WMClient {
@@ -69,6 +78,8 @@ impl WMClient {
             last_application: String::new(),
             last_window: String::new(),
             log_window_changes,
+            application_cache: None,
+            title_cache: None,
         }
     }
 
@@ -126,6 +137,51 @@ impl WMClient {
         self.client
             .close_windows_by_app_class(&app_class)
             .context("Failed to close by app_class.")
+    }
+
+    pub fn clear_app_class_and_title(&mut self) {
+        self.application_cache = None; // expire cache
+        self.title_cache = None; // expire cache
+    }
+
+    pub fn match_window(&mut self, window_matcher: &OnlyOrNot) -> bool {
+        // Lazily fill the wm_class cache
+        if self.title_cache.is_none() {
+            match self.current_window() {
+                Some(title) => self.title_cache = Some(title),
+                None => self.title_cache = Some(String::new()),
+            }
+        }
+
+        if let Some(title) = &self.title_cache {
+            if let Some(title_only) = &window_matcher.only {
+                return title_only.iter().any(|m| m.matches(title));
+            }
+            if let Some(title_not) = &window_matcher.not {
+                return title_not.iter().all(|m| !m.matches(title));
+            }
+        }
+        false
+    }
+
+    pub fn match_application(&mut self, application_matcher: &OnlyOrNot) -> bool {
+        // Lazily fill the wm_class cache
+        if self.application_cache.is_none() {
+            match self.current_application() {
+                Some(application) => self.application_cache = Some(application),
+                None => self.application_cache = Some(String::new()),
+            }
+        }
+
+        if let Some(application) = &self.application_cache {
+            if let Some(application_only) = &application_matcher.only {
+                return application_only.iter().any(|m| m.matches(application));
+            }
+            if let Some(application_not) = &application_matcher.not {
+                return application_not.iter().all(|m| !m.matches(application));
+            }
+        }
+        false
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,7 +26,7 @@ mod wlroots_client;
 #[cfg(feature = "x11")]
 mod x11_client;
 
-mod null_client;
+pub mod null_client;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct WindowInfo {

--- a/src/config/expmap.rs
+++ b/src/config/expmap.rs
@@ -1,3 +1,4 @@
+use crate::config::application::OnlyOrNot;
 use crate::config::modmap::KeyWrapper;
 use crate::config::{expmap_operator::ExpmapOperator, expmap_simkey::Simkey};
 use evdev::KeyCode as Key;
@@ -14,6 +15,8 @@ pub struct Expmap {
     pub chords: Vec<Simkey>,
     #[serde(default, deserialize_with = "deserialize_experimental_remap")]
     pub remap: HashMap<Key, ExpmapOperator>,
+    pub application: Option<OnlyOrNot>,
+    pub window: Option<OnlyOrNot>,
 }
 
 pub fn deserialize_experimental_remap<'de, D>(deserializer: D) -> Result<HashMap<Key, ExpmapOperator>, D::Error>

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -61,11 +61,7 @@ pub fn build_keymap_table(keymaps: &Vec<Keymap>) -> HashMap<Key, Vec<KeymapEntry
     let mut table: HashMap<Key, Vec<KeymapEntry>> = HashMap::new();
     for keymap in keymaps {
         for (key_press, actions) in keymap.remap.iter() {
-            let mut entries: Vec<KeymapEntry> = match table.get(&key_press.key) {
-                Some(entries) => entries.to_vec(),
-                None => vec![],
-            };
-            entries.push(KeymapEntry {
+            let entry = KeymapEntry {
                 actions: actions.to_vec(),
                 modifiers: key_press.modifiers.clone(),
                 application: keymap.application.clone(),
@@ -73,8 +69,15 @@ pub fn build_keymap_table(keymaps: &Vec<Keymap>) -> HashMap<Key, Vec<KeymapEntry
                 device: keymap.device.clone(),
                 mode: keymap.mode.clone(),
                 exact_match: keymap.exact_match,
-            });
-            table.insert(key_press.key, entries);
+            };
+            match table.get_mut(&key_press.key) {
+                Some(entries) => {
+                    entries.push(entry);
+                }
+                None => {
+                    table.insert(key_press.key, vec![entry]);
+                }
+            };
         }
     }
     table

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@ pub mod application;
 pub mod device;
 mod expmap;
 pub mod expmap_operator;
-mod expmap_simkey;
+pub mod expmap_simkey;
 mod key;
 pub mod key_press;
 pub mod keymap;
@@ -15,7 +15,7 @@ mod tests;
 mod validation;
 mod watcher;
 
-use crate::config::expmap::Expmap;
+pub use crate::config::expmap::Expmap;
 use crate::config::key::parse_key;
 use crate::config::keymap::{build_keymap_table, KeymapEntry};
 use crate::event_handler::DISGUISED_EVENT_OFFSETTER;

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -1,6 +1,5 @@
 use crate::action::Action;
 use crate::client::WMClient;
-use crate::config::application::OnlyOrNot;
 use crate::config::key_press::{KeyPress, Modifier};
 use crate::config::keymap::{build_override_table, OverrideEntry};
 use crate::config::keymap_action::KeymapAction;
@@ -34,8 +33,6 @@ pub struct EventHandler {
     extra_modifiers: HashSet<Key>,
     // Make sure the original event is released even if remapping changes while holding the key
     pressed_keys: HashMap<Key, Key>,
-    application_cache: Option<String>,
-    title_cache: Option<String>,
     // State machine for multi-purpose keys
     multi_purpose_keys: HashMap<Key, MultiPurposeKeyState>,
     // Current nested remaps
@@ -67,8 +64,6 @@ impl EventHandler {
             modifiers: vec![],
             extra_modifiers: HashSet::new(),
             pressed_keys: HashMap::new(),
-            application_cache: None,
-            title_cache: None,
             multi_purpose_keys: HashMap::new(),
             override_remaps: vec![],
             override_timeout_key: None,
@@ -92,8 +87,7 @@ impl EventHandler {
         // a vector to collect mouse movement events to be able to send them all at once as one MouseMovementEventCollection.
         let mut mouse_movement_collection: Vec<RelativeEvent> = Vec::new();
         for event in events {
-            self.application_cache = None; // expire cache
-            self.title_cache = None; // expire cache
+            wmclient.clear_app_class_and_title();
 
             if let Event::KeyEvent(_, key_event) = event {
                 debug!("=> {}: {:?}", key_event.value(), &key_event.key);
@@ -428,12 +422,12 @@ impl EventHandler {
         for modmap in &config.modmap {
             if let Some(key_action) = modmap.remap.get(key) {
                 if let Some(window_matcher) = &modmap.window {
-                    if !self.match_window(wmclient, window_matcher) {
+                    if !wmclient.match_window(window_matcher) {
                         continue;
                     }
                 }
                 if let Some(application_matcher) = &modmap.application {
-                    if !self.match_application(wmclient, application_matcher) {
+                    if !wmclient.match_application(application_matcher) {
                         continue;
                     }
                 }
@@ -513,13 +507,13 @@ impl EventHandler {
                         continue;
                     }
                     if let Some(window_matcher) = &entry.title {
-                        if !self.match_window(wmclient, window_matcher) {
+                        if !wmclient.match_window(window_matcher) {
                             continue;
                         }
                     }
 
                     if let Some(application_matcher) = &entry.application {
-                        if !self.match_application(wmclient, application_matcher) {
+                        if !wmclient.match_application(application_matcher) {
                             continue;
                         }
                     }
@@ -672,46 +666,6 @@ impl EventHandler {
             })
             .collect();
         (extra_modifiers, missing_modifiers)
-    }
-
-    fn match_window(&mut self, wmclient: &mut WMClient, window_matcher: &OnlyOrNot) -> bool {
-        // Lazily fill the wm_class cache
-        if self.title_cache.is_none() {
-            match wmclient.current_window() {
-                Some(title) => self.title_cache = Some(title),
-                None => self.title_cache = Some(String::new()),
-            }
-        }
-
-        if let Some(title) = &self.title_cache {
-            if let Some(title_only) = &window_matcher.only {
-                return title_only.iter().any(|m| m.matches(title));
-            }
-            if let Some(title_not) = &window_matcher.not {
-                return title_not.iter().all(|m| !m.matches(title));
-            }
-        }
-        false
-    }
-
-    fn match_application(&mut self, wmclient: &mut WMClient, application_matcher: &OnlyOrNot) -> bool {
-        // Lazily fill the wm_class cache
-        if self.application_cache.is_none() {
-            match wmclient.current_application() {
-                Some(application) => self.application_cache = Some(application),
-                None => self.application_cache = Some(String::new()),
-            }
-        }
-
-        if let Some(application) = &self.application_cache {
-            if let Some(application_only) = &application_matcher.only {
-                return application_only.iter().any(|m| m.matches(application));
-            }
-            if let Some(application_not) = &application_matcher.not {
-                return application_not.iter().all(|m| !m.matches(application));
-            }
-        }
-        false
     }
 
     fn update_modifier(&mut self, key: Key, value: i32) {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -100,7 +100,7 @@ impl EventHandler {
             }
 
             // Apply modmap
-            let modmap_events = self.apply_modmap(config, &event, wmclient)?;
+            let modmap_events = self.apply_modmap(config, event, wmclient)?;
 
             // Apply keymap
             for event in modmap_events.into_iter() {
@@ -371,10 +371,10 @@ impl EventHandler {
     fn apply_modmap(
         &mut self,
         config: &Config,
-        event: &Event,
+        event: Event,
         wmclient: &mut WMClient,
     ) -> Result<Vec<Event>, Box<dyn Error>> {
-        match event {
+        match &event {
             Event::KeyEvent(device, key_event) => {
                 let key = key_event.key;
                 let value = key_event.value();
@@ -410,11 +410,11 @@ impl EventHandler {
                     .map(|(key, value)| Event::KeyEvent(device.clone(), KeyEvent::new_with(key.code(), value)))
                     .collect();
 
-                events.push(event.clone());
+                events.push(event);
 
                 Ok(events)
             }
-            event => Ok(vec![event.clone()]),
+            _ => Ok(vec![event]),
         }
     }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -86,7 +86,8 @@ impl EventHandler {
         operator_handler: &mut Option<OperatorHandler>,
     ) -> Result<Vec<Action>, Box<dyn Error>> {
         if let Some(handler) = operator_handler {
-            events = handler.map_events(events);
+            wmclient.clear_app_class_and_title();
+            events = handler.map_events(events, wmclient);
         };
 
         debug_assert!(self.actions.is_empty());

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -7,6 +7,7 @@ use crate::config::modmap_operator::{Interruptable, Keys, ModmapOperator, MultiP
 use crate::config::nested_remap::Remap;
 use crate::device::InputDeviceInfo;
 use crate::event::{Event, KeyEvent, RelativeEvent};
+use crate::operator_handler::OperatorHandler;
 use crate::Config;
 use evdev::KeyCode as Key;
 use lazy_static::lazy_static;
@@ -79,10 +80,15 @@ impl EventHandler {
     // Handle an Event and return Actions. This should be the only public method of EventHandler.
     pub fn on_events(
         &mut self,
-        events: Vec<Event>,
+        mut events: Vec<Event>,
         config: &Config,
         wmclient: &mut WMClient,
+        operator_handler: &mut Option<OperatorHandler>,
     ) -> Result<Vec<Action>, Box<dyn Error>> {
+        if let Some(handler) = operator_handler {
+            events = handler.map_events(events);
+        };
+
         debug_assert!(self.actions.is_empty());
         // a vector to collect mouse movement events to be able to send them all at once as one MouseMovementEventCollection.
         let mut mouse_movement_collection: Vec<RelativeEvent> = Vec::new();

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -79,7 +79,7 @@ impl EventHandler {
     // Handle an Event and return Actions. This should be the only public method of EventHandler.
     pub fn on_events(
         &mut self,
-        events: &Vec<Event>,
+        events: Vec<Event>,
         config: &Config,
         wmclient: &mut WMClient,
     ) -> Result<Vec<Action>, Box<dyn Error>> {
@@ -89,12 +89,12 @@ impl EventHandler {
         for event in events {
             wmclient.clear_app_class_and_title();
 
-            if let Event::KeyEvent(_, key_event) = event {
+            if let Event::KeyEvent(_, key_event) = &event {
                 debug!("=> {}: {:?}", key_event.value(), &key_event.key);
             }
 
             // Apply modmap
-            let modmap_events = self.apply_modmap(config, event, wmclient)?;
+            let modmap_events = self.apply_modmap(config, &event, wmclient)?;
 
             // Apply keymap
             for event in modmap_events.into_iter() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use crate::device::{
 use crate::event_handler::EventHandler;
 use crate::main_controller::MainController;
 use crate::operator_handler::OperatorHandler;
-use crate::operators::get_operator_handler;
 use crate::throttle_emit::ThrottleEmit;
 use crate::timeout_manager::TimeoutManager;
 use action_dispatcher::ActionDispatcher;
@@ -263,7 +262,11 @@ fn main() -> anyhow::Result<()> {
         Some(ThrottleEmit::new(Duration::from_millis(config.throttle_ms)))
     };
 
-    let mut operator_handler = get_operator_handler(&config.experimental_map, timeout_manager.clone());
+    let mut operator_handler = if config.experimental_map.len() > 0 {
+        Some(OperatorHandler::new(&config.experimental_map, timeout_manager.clone()))
+    } else {
+        None
+    };
 
     let mut dispatcher = ActionDispatcher::new(output_device, throttle_emit);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,8 +419,8 @@ fn handle_events(
         events = handler.map_events(events);
     };
     let actions = handler
-        .on_events(&events, config, mainctrl.wmclient())
-        .map_err(|e| anyhow!("Failed handling {events:?}:\n  {e:?}"))?;
+        .on_events(events, config, mainctrl.wmclient())
+        .map_err(|err| anyhow!("EventHandler failed: {err:?}"))?;
     for action in actions {
         dispatcher.on_action(action, mainctrl)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,15 +411,12 @@ fn handle_events(
     handler: &mut EventHandler,
     dispatcher: &mut ActionDispatcher,
     config: &Config,
-    mut events: Vec<Event>,
+    events: Vec<Event>,
     operator_handler: &mut Option<OperatorHandler>,
     mainctrl: &mut MainController,
 ) -> anyhow::Result<()> {
-    if let Some(handler) = operator_handler {
-        events = handler.map_events(events);
-    };
     let actions = handler
-        .on_events(events, config, mainctrl.wmclient())
+        .on_events(events, config, mainctrl.wmclient(), operator_handler)
         .map_err(|err| anyhow!("EventHandler failed: {err:?}"))?;
     for action in actions {
         dispatcher.on_action(action, mainctrl)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn main() -> anyhow::Result<()> {
         Some(ThrottleEmit::new(Duration::from_millis(config.throttle_ms)))
     };
 
-    let mut operator_handler = get_operator_handler(&config, timeout_manager.clone());
+    let mut operator_handler = get_operator_handler(&config.experimental_map, timeout_manager.clone());
 
     let mut dispatcher = ActionDispatcher::new(output_device, throttle_emit);
 

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -1,3 +1,4 @@
+use crate::client::WMClient;
 use crate::config::expmap_operator::ExpmapOperator;
 use crate::config::Expmap;
 use crate::emit_handler::{Emit, EmitHandler};
@@ -5,7 +6,7 @@ use crate::event::Event;
 use crate::event_handler::PRESS;
 use crate::operator_double_tap::DoubleTapOperator;
 use crate::operator_sim::SimOperator;
-use crate::operators::{ActiveOperator, OperatorAction, StaticOperator};
+use crate::operators::{ActiveOperator, OperatorAction, OperatorEntry, StaticOperator};
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
 use std::collections::HashMap;
@@ -15,7 +16,7 @@ use std::usize;
 pub struct OperatorHandler {
     active: Vec<Box<dyn ActiveOperator>>,
     candidates: Option<Candidates>,
-    lookup_map: HashMap<Key, Vec<Box<dyn StaticOperator>>>,
+    lookup_map: HashMap<Key, Vec<OperatorEntry>>,
     emit_handler: EmitHandler,
 }
 
@@ -41,44 +42,56 @@ pub struct OperatorHandler {
 /// because they would have to keep track of the whether 'b' should be squashed or let through.
 impl OperatorHandler {
     pub fn new(experimental_map: &Vec<Expmap>, timeout_manager: Rc<TimeoutManager>) -> OperatorHandler {
-        let mut lookup_map: HashMap<Key, Vec<Box<dyn StaticOperator>>> = HashMap::new();
+        let mut lookup_map: HashMap<Key, Vec<OperatorEntry>> = HashMap::new();
 
         for expmap in experimental_map {
             for chord in &expmap.chords {
-                let operator = Box::new(SimOperator {
+                let operators = SimOperator {
                     keys: chord.keys.clone(),
                     actions: chord.actions.clone(),
                     timeout: chord.timeout,
                     timeout_manager: timeout_manager.clone(),
-                });
-                for (key, op) in operator.get_operators() {
+                }
+                .get_operators();
+                for (key, operator) in operators {
+                    let entry = OperatorEntry {
+                        operator,
+                        application: expmap.application.clone(),
+                        title: expmap.window.clone(),
+                    };
                     match lookup_map.get_mut(&key) {
                         Some(current) => {
-                            current.push(op);
+                            current.push(entry);
                         }
                         None => {
-                            lookup_map.insert(key, vec![op]);
+                            lookup_map.insert(key, vec![entry]);
                         }
                     };
                 }
             }
 
             for (key, op) in &expmap.remap {
-                let operator = match op {
-                    ExpmapOperator::DoubleTap(dbltap) => Box::new(DoubleTapOperator {
+                let operators = match op {
+                    ExpmapOperator::DoubleTap(dbltap) => DoubleTapOperator {
                         key: key.clone(),
                         actions: dbltap.actions.clone(),
                         timeout: dbltap.timeout,
                         timeout_manager: timeout_manager.clone(),
-                    }),
-                };
-                for (key, op) in operator.get_operators() {
+                    },
+                }
+                .get_operators();
+                for (key, operator) in operators {
+                    let entry = OperatorEntry {
+                        operator,
+                        application: expmap.application.clone(),
+                        title: expmap.window.clone(),
+                    };
                     match lookup_map.get_mut(&key) {
                         Some(current) => {
-                            current.push(op);
+                            current.push(entry);
                         }
                         None => {
-                            lookup_map.insert(key, vec![op]);
+                            lookup_map.insert(key, vec![entry]);
                         }
                     };
                 }
@@ -106,16 +119,17 @@ impl OperatorHandler {
 
     #[cfg(test)]
     pub fn map_evs(&mut self, events: Vec<Event>) -> Vec<Event> {
-        self.map_events(events)
+        let mut wmclient = WMClient::new("none", Box::new(crate::client::null_client::NullClient), false);
+        self.map_events(events, &mut wmclient)
     }
 
-    pub fn map_events(&mut self, events: Vec<Event>) -> Vec<Event> {
+    pub fn map_events(&mut self, events: Vec<Event>, wmclient: &mut WMClient) -> Vec<Event> {
         events
             .into_iter()
             .flat_map(|event| {
                 self.emit_handler.on_event(&event);
 
-                let events = process_event(event, &mut self.active, &mut self.candidates, &self.lookup_map);
+                let events = process_event(event, &mut self.active, &mut self.candidates, &self.lookup_map, wmclient);
 
                 self.emit_handler.map_output(events)
             })
@@ -163,7 +177,8 @@ fn process_event(
     event: Event,
     right: &mut Vec<Box<dyn ActiveOperator>>,
     candidates: &mut Option<Candidates>,
-    lookup_map: &HashMap<Key, Vec<Box<dyn StaticOperator>>>,
+    lookup_map: &HashMap<Key, Vec<OperatorEntry>>,
+    wmclient: &mut WMClient,
 ) -> Vec<Emit> {
     // The events that have passed fully through the operators.
     let mut emit: Vec<Emit> = vec![];
@@ -205,7 +220,7 @@ fn process_event(
                     None => {
                         match candidates {
                             Some(candidates) => try_candidates(event, &mut left, candidates),
-                            None => static_lookup(event, candidates, &lookup_map, &mut emit),
+                            None => static_lookup(event, candidates, &lookup_map, &mut emit, wmclient),
                         };
                     }
                 };
@@ -326,8 +341,9 @@ fn try_candidates(event: Event, left: &mut Vec<Node>, candidates: &mut Candidate
 fn static_lookup(
     event: Event,
     candidates: &mut Option<Candidates>,
-    lookup_map: &HashMap<Key, Vec<Box<dyn StaticOperator>>>,
+    lookup_map: &HashMap<Key, Vec<OperatorEntry>>,
     emit: &mut Vec<Emit>,
+    wmclient: &mut WMClient,
 ) {
     let (device, key_event) = match &event {
         Event::KeyEvent(device, key_event) => (device, key_event),
@@ -348,14 +364,29 @@ fn static_lookup(
 
     // Static operators
     match lookup_map.get(&key_event.key) {
-        Some(operators) => {
-            debug_assert!(!operators.is_empty());
+        Some(entries) => {
+            debug_assert!(!entries.is_empty());
             debug_assert!(candidates.is_none());
 
-            let new_candidates: Vec<_> = operators
+            let new_candidates: Vec<_> = entries
                 .iter()
-                .map(|operator| Candidate {
-                    operator: operator.get_active_operator(&event),
+                .filter(|entry| {
+                    if let Some(window_matcher) = &entry.title {
+                        if !wmclient.match_window(window_matcher) {
+                            return false;
+                        }
+                    }
+
+                    if let Some(application_matcher) = &entry.application {
+                        if !wmclient.match_application(application_matcher) {
+                            return false;
+                        }
+                    }
+
+                    true
+                })
+                .map(|entry| Candidate {
+                    operator: entry.operator.get_active_operator(&event),
                     state: CandidateState::Matching,
                     emitted: vec![],
                     unhandled: vec![],

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -1,9 +1,15 @@
+use crate::config::expmap_operator::ExpmapOperator;
+use crate::config::Expmap;
 use crate::emit_handler::{Emit, EmitHandler};
 use crate::event::Event;
 use crate::event_handler::PRESS;
+use crate::operator_double_tap::DoubleTapOperator;
+use crate::operator_sim::SimOperator;
 use crate::operators::{ActiveOperator, OperatorAction, StaticOperator};
+use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::usize;
 
 pub struct OperatorHandler {
@@ -34,7 +40,46 @@ pub struct OperatorHandler {
 /// handles the last part 'AB'. If operators were only static, then it would be more complicated
 /// because they would have to keep track of the whether 'b' should be squashed or let through.
 impl OperatorHandler {
-    pub fn new(operators: Vec<Box<dyn StaticOperator>>) -> OperatorHandler {
+    pub fn new(experimental_map: &Vec<Expmap>, timeout_manager: Rc<TimeoutManager>) -> OperatorHandler {
+        let operators: Vec<_> = experimental_map
+            .iter()
+            .flat_map(|expmap| {
+                let chords: Vec<_> = expmap
+                    .chords
+                    .iter()
+                    .map(|chord| -> Box<dyn StaticOperator> {
+                        Box::new(SimOperator {
+                            keys: chord.keys.clone(),
+                            actions: chord.actions.clone(),
+                            timeout: chord.timeout,
+                            timeout_manager: timeout_manager.clone(),
+                        })
+                    })
+                    .collect();
+
+                let rest: Vec<_> = expmap
+                    .remap
+                    .iter()
+                    .map(|(key, op)| -> Box<dyn StaticOperator> {
+                        match op {
+                            ExpmapOperator::DoubleTap(dbltap) => Box::new(DoubleTapOperator {
+                                key: key.clone(),
+                                actions: dbltap.actions.clone(),
+                                timeout: dbltap.timeout,
+                                timeout_manager: timeout_manager.clone(),
+                            }),
+                        }
+                    })
+                    .collect();
+
+                let mut operators: Vec<Box<dyn StaticOperator>> = vec![];
+                operators.extend(chords);
+                operators.extend(rest);
+
+                operators
+            })
+            .collect();
+
         let mut lookup_map: HashMap<Key, Vec<Box<dyn StaticOperator>>> = HashMap::new();
 
         for operator in &operators {

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -67,6 +67,11 @@ impl OperatorHandler {
         self.emit_handler.assert_emitted_modifiers_are_synced();
     }
 
+    #[cfg(test)]
+    pub fn map_evs(&mut self, events: Vec<Event>) -> Vec<Event> {
+        self.map_events(events)
+    }
+
     pub fn map_events(&mut self, events: Vec<Event>) -> Vec<Event> {
         events
             .into_iter()

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -41,55 +41,47 @@ pub struct OperatorHandler {
 /// because they would have to keep track of the whether 'b' should be squashed or let through.
 impl OperatorHandler {
     pub fn new(experimental_map: &Vec<Expmap>, timeout_manager: Rc<TimeoutManager>) -> OperatorHandler {
-        let operators: Vec<_> = experimental_map
-            .iter()
-            .flat_map(|expmap| {
-                let chords: Vec<_> = expmap
-                    .chords
-                    .iter()
-                    .map(|chord| -> Box<dyn StaticOperator> {
-                        Box::new(SimOperator {
-                            keys: chord.keys.clone(),
-                            actions: chord.actions.clone(),
-                            timeout: chord.timeout,
-                            timeout_manager: timeout_manager.clone(),
-                        })
-                    })
-                    .collect();
-
-                let rest: Vec<_> = expmap
-                    .remap
-                    .iter()
-                    .map(|(key, op)| -> Box<dyn StaticOperator> {
-                        match op {
-                            ExpmapOperator::DoubleTap(dbltap) => Box::new(DoubleTapOperator {
-                                key: key.clone(),
-                                actions: dbltap.actions.clone(),
-                                timeout: dbltap.timeout,
-                                timeout_manager: timeout_manager.clone(),
-                            }),
-                        }
-                    })
-                    .collect();
-
-                let mut operators: Vec<Box<dyn StaticOperator>> = vec![];
-                operators.extend(chords);
-                operators.extend(rest);
-
-                operators
-            })
-            .collect();
-
         let mut lookup_map: HashMap<Key, Vec<Box<dyn StaticOperator>>> = HashMap::new();
 
-        for operator in &operators {
-            for (key, op) in operator.get_operators() {
-                match lookup_map.get_mut(&key) {
-                    Some(current) => current.push(op),
-                    None => {
-                        lookup_map.insert(key, vec![op]);
-                    }
+        for expmap in experimental_map {
+            for chord in &expmap.chords {
+                let operator = Box::new(SimOperator {
+                    keys: chord.keys.clone(),
+                    actions: chord.actions.clone(),
+                    timeout: chord.timeout,
+                    timeout_manager: timeout_manager.clone(),
+                });
+                for (key, op) in operator.get_operators() {
+                    match lookup_map.get_mut(&key) {
+                        Some(current) => {
+                            current.push(op);
+                        }
+                        None => {
+                            lookup_map.insert(key, vec![op]);
+                        }
+                    };
+                }
+            }
+
+            for (key, op) in &expmap.remap {
+                let operator = match op {
+                    ExpmapOperator::DoubleTap(dbltap) => Box::new(DoubleTapOperator {
+                        key: key.clone(),
+                        actions: dbltap.actions.clone(),
+                        timeout: dbltap.timeout,
+                        timeout_manager: timeout_manager.clone(),
+                    }),
                 };
+                for (key, op) in operator.get_operators() {
+                    match lookup_map.get_mut(&key) {
+                        Some(current) => {
+                            current.push(op);
+                        }
+                        None => {
+                            lookup_map.insert(key, vec![op]);
+                        }
+                    };
+                }
             }
         }
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1,5 +1,5 @@
 use crate::config::expmap_operator::{ExpmapAction, ExpmapOperator};
-use crate::config::Config;
+use crate::config::Expmap;
 use crate::device::InputDeviceInfo;
 use crate::emit_handler::Emit;
 use crate::event::{Event, KeyEvent, KeyValue};
@@ -50,9 +50,11 @@ pub fn map_actions(actions: &Vec<ExpmapAction>, device: Rc<InputDeviceInfo>, val
         .collect()
 }
 
-pub fn get_operator_handler(config: &Config, timeout_manager: Rc<TimeoutManager>) -> Option<OperatorHandler> {
-    let operators: Vec<_> = config
-        .experimental_map
+pub fn get_operator_handler(
+    experimental_map: &Vec<Expmap>,
+    timeout_manager: Rc<TimeoutManager>,
+) -> Option<OperatorHandler> {
+    let operators: Vec<_> = experimental_map
         .iter()
         .flat_map(|expmap| {
             let chords: Vec<_> = expmap

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1,3 +1,4 @@
+use crate::config::application::OnlyOrNot;
 use crate::config::expmap_operator::ExpmapAction;
 use crate::device::InputDeviceInfo;
 use crate::emit_handler::Emit;
@@ -43,4 +44,12 @@ pub fn map_actions(actions: &Vec<ExpmapAction>, device: Rc<InputDeviceInfo>, val
             ExpmapAction::Key(key) => Some(Emit::key_event(device.clone(), KeyEvent::new(*key, value))),
         })
         .collect()
+}
+
+// Internals for efficient operator lookup
+#[derive(Debug)]
+pub struct OperatorEntry {
+    pub operator: Box<dyn StaticOperator>,
+    pub application: Option<OnlyOrNot>,
+    pub title: Option<OnlyOrNot>,
 }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1,12 +1,7 @@
-use crate::config::expmap_operator::{ExpmapAction, ExpmapOperator};
-use crate::config::Expmap;
+use crate::config::expmap_operator::ExpmapAction;
 use crate::device::InputDeviceInfo;
 use crate::emit_handler::Emit;
 use crate::event::{Event, KeyEvent, KeyValue};
-use crate::operator_double_tap::DoubleTapOperator;
-use crate::operator_handler::OperatorHandler;
-use crate::operator_sim::SimOperator;
-use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
 use std::fmt::Debug;
 use std::rc::Rc;
@@ -48,54 +43,4 @@ pub fn map_actions(actions: &Vec<ExpmapAction>, device: Rc<InputDeviceInfo>, val
             ExpmapAction::Key(key) => Some(Emit::key_event(device.clone(), KeyEvent::new(*key, value))),
         })
         .collect()
-}
-
-pub fn get_operator_handler(
-    experimental_map: &Vec<Expmap>,
-    timeout_manager: Rc<TimeoutManager>,
-) -> Option<OperatorHandler> {
-    let operators: Vec<_> = experimental_map
-        .iter()
-        .flat_map(|expmap| {
-            let chords: Vec<_> = expmap
-                .chords
-                .iter()
-                .map(|chord| -> Box<dyn StaticOperator> {
-                    Box::new(SimOperator {
-                        keys: chord.keys.clone(),
-                        actions: chord.actions.clone(),
-                        timeout: chord.timeout,
-                        timeout_manager: timeout_manager.clone(),
-                    })
-                })
-                .collect();
-
-            let rest: Vec<_> = expmap
-                .remap
-                .iter()
-                .map(|(key, op)| -> Box<dyn StaticOperator> {
-                    match op {
-                        ExpmapOperator::DoubleTap(dbltap) => Box::new(DoubleTapOperator {
-                            key: key.clone(),
-                            actions: dbltap.actions.clone(),
-                            timeout: dbltap.timeout,
-                            timeout_manager: timeout_manager.clone(),
-                        }),
-                    }
-                })
-                .collect();
-
-            let mut operators: Vec<Box<dyn StaticOperator>> = vec![];
-            operators.extend(chords);
-            operators.extend(rest);
-
-            operators
-        })
-        .collect();
-
-    if operators.len() > 0 {
-        Some(OperatorHandler::new(operators))
-    } else {
-        None
-    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -597,7 +597,7 @@ impl EventHandlerForTest {
             format!(
                 "{:?}",
                 self.event_handler
-                    .on_events(events, &self.config, &mut self.wmclient)
+                    .on_events(events, &self.config, &mut self.wmclient, &mut None)
                     .unwrap()
             )
         );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -597,7 +597,7 @@ impl EventHandlerForTest {
             format!(
                 "{:?}",
                 self.event_handler
-                    .on_events(&events, &self.config, &mut self.wmclient)
+                    .on_events(events, &self.config, &mut self.wmclient)
                     .unwrap()
             )
         );

--- a/src/tests_operator_double_tap.rs
+++ b/src/tests_operator_double_tap.rs
@@ -31,8 +31,8 @@ fn get_handler() -> OperatorHandler {
 fn test_dbltap_key_not_matching() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -42,19 +42,16 @@ fn test_dbltap_key_not_matching() {
 fn test_dbltap_at_first_press_not_canceled_by_other_non_matching() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
         vec![Event::key_press(Key::KEY_1), Event::key_press(Key::KEY_LEFTALT)],
     );
 
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
 }
@@ -63,23 +60,23 @@ fn test_dbltap_at_first_press_not_canceled_by_other_non_matching() {
 fn test_dbltap_at_first_press_canceled_by_timeout() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
     thread::sleep(TIMEOUT);
 
     assert_events(
-        handler.map_events(vec![Event::Tick]),
+        handler.map_evs(vec![Event::Tick]),
         vec![Event::key_press(Key::KEY_LEFTCTRL), Event::key_press(Key::KEY_A)],
     );
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
         vec![Event::key_release(Key::KEY_LEFTCTRL)],
     );
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -89,15 +86,12 @@ fn test_dbltap_at_first_press_canceled_by_timeout() {
 fn test_dbltap_at_first_press_repeated() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -107,21 +101,18 @@ fn test_dbltap_at_first_press_repeated() {
 fn test_dbltap_when_tapped_not_canceled_by_other_non_matching() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
         vec![Event::key_press(Key::KEY_1), Event::key_press(Key::KEY_LEFTALT)],
     );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTALT)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTALT)]),
         vec![Event::key_release(Key::KEY_LEFTALT)],
     );
 
@@ -133,15 +124,15 @@ fn test_dbltap_when_tapped_not_canceled_by_other_non_matching() {
 fn test_dbltap_when_tapped_canceled_by_timeout() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
     thread::sleep(TIMEOUT);
 
     assert_events(
-        handler.map_events(vec![Event::Tick]),
+        handler.map_evs(vec![Event::Tick]),
         vec![
             Event::key_press(Key::KEY_LEFTCTRL),
             Event::key_release(Key::KEY_LEFTCTRL),
@@ -156,17 +147,17 @@ fn test_dbltap_when_tapped_canceled_by_timeout() {
 fn test_dbltap_when_tapped_canceled_by_timeout_with_rolled_key() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
     thread::sleep(TIMEOUT);
 
     assert_events(
-        handler.map_events(vec![Event::Tick]),
+        handler.map_evs(vec![Event::Tick]),
         vec![
             Event::key_press(Key::KEY_LEFTCTRL),
             Event::key_press(Key::KEY_A),
@@ -183,17 +174,17 @@ fn test_dbltap_when_tapped_canceled_by_timeout_with_rolled_key() {
 fn test_dbltap_when_tapped_canceled_by_timeout_with_modded_key() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
     thread::sleep(TIMEOUT);
 
     assert_events(
-        handler.map_events(vec![Event::Tick]),
+        handler.map_evs(vec![Event::Tick]),
         vec![
             Event::key_press(Key::KEY_LEFTCTRL),
             Event::key_press(Key::KEY_A),
@@ -210,17 +201,17 @@ fn test_dbltap_when_tapped_canceled_by_timeout_with_modded_key() {
 fn test_dbltap_when_tapped_canceled_by_timeout_with_distinct_key() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
     thread::sleep(TIMEOUT);
 
     assert_events(
-        handler.map_events(vec![Event::Tick]),
+        handler.map_evs(vec![Event::Tick]),
         vec![
             Event::key_press(Key::KEY_LEFTCTRL),
             Event::key_release(Key::KEY_LEFTCTRL),
@@ -237,24 +228,21 @@ fn test_dbltap_when_tapped_canceled_by_timeout_with_distinct_key() {
 fn test_dbltap_spurious_events() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
     // Spurious release
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
     // Spurious repeat
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
 
     // Spurious press
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -264,14 +252,11 @@ fn test_dbltap_spurious_events() {
 fn test_dbltap() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -281,23 +266,17 @@ fn test_dbltap() {
 fn test_dbltap_twice() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -307,20 +286,17 @@ fn test_dbltap_twice() {
 fn test_dbltap_then_tick_before_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
     thread::sleep(TIMEOUT);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -330,15 +306,12 @@ fn test_dbltap_then_tick_before_release() {
 fn test_dbltap_then_repeat_triggering_key() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_LEFTCTRL)]), vec![Event::key_repeat(Key::KEY_1)]);
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_LEFTCTRL)]), vec![Event::key_repeat(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -348,23 +321,20 @@ fn test_dbltap_then_repeat_triggering_key() {
 fn test_dbltap_then_repeat_ordinary_key() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
         vec![Event::key_press(Key::KEY_1), Event::key_press(Key::KEY_A)],
     );
 
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_A)]);
 
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -374,23 +344,17 @@ fn test_dbltap_then_repeat_ordinary_key() {
 fn test_dbltap_surrounded_at_first_press() {
     let mut handler = get_handler();
 
-    assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTALT)]),
-        vec![Event::key_press(Key::KEY_LEFTALT)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![Event::key_press(Key::KEY_LEFTALT)]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTALT)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTALT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
         vec![Event::key_press(Key::KEY_1), Event::key_release(Key::KEY_LEFTALT)],
     );
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -400,23 +364,17 @@ fn test_dbltap_surrounded_at_first_press() {
 fn test_dbltap_surrounded_at_tapped() {
     let mut handler = get_handler();
 
-    assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTALT)]),
-        vec![Event::key_press(Key::KEY_LEFTALT)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![Event::key_press(Key::KEY_LEFTALT)]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTALT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTALT)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
         vec![Event::key_press(Key::KEY_1), Event::key_release(Key::KEY_LEFTALT)],
     );
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -426,25 +384,22 @@ fn test_dbltap_surrounded_at_tapped() {
 fn test_dbltap_surrounded_at_double_tapped() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTALT)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTCTRL)]),
         vec![Event::key_press(Key::KEY_1), Event::key_press(Key::KEY_LEFTALT)],
     );
 
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTALT)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTALT)]),
         vec![Event::key_release(Key::KEY_LEFTALT)],
     );
 
-    assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_LEFTCTRL)]),
-        vec![Event::key_release(Key::KEY_1)],
-    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();

--- a/src/tests_operator_double_tap.rs
+++ b/src/tests_operator_double_tap.rs
@@ -23,6 +23,8 @@ fn get_handler() -> OperatorHandler {
                 timeout: TIMEOUT,
             }),
         )]),
+        application: None,
+        window: None,
     }];
 
     OperatorHandler::new(&config, Rc::new(TimeoutManager::new()))

--- a/src/tests_operator_double_tap.rs
+++ b/src/tests_operator_double_tap.rs
@@ -2,7 +2,6 @@ use crate::config::expmap_operator::{DoubleTap, ExpmapAction, ExpmapOperator};
 use crate::config::Expmap;
 use crate::event::Event;
 use crate::operator_handler::OperatorHandler;
-use crate::operators::get_operator_handler;
 use crate::tests::assert_events;
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
@@ -26,7 +25,7 @@ fn get_handler() -> OperatorHandler {
         )]),
     }];
 
-    get_operator_handler(&config, Rc::new(TimeoutManager::new())).unwrap()
+    OperatorHandler::new(&config, Rc::new(TimeoutManager::new()))
 }
 
 #[test]

--- a/src/tests_operator_double_tap.rs
+++ b/src/tests_operator_double_tap.rs
@@ -1,11 +1,12 @@
-use crate::config::expmap_operator::ExpmapAction;
+use crate::config::expmap_operator::{DoubleTap, ExpmapAction, ExpmapOperator};
+use crate::config::Expmap;
 use crate::event::Event;
-use crate::operator_double_tap::DoubleTapOperator;
 use crate::operator_handler::OperatorHandler;
-use crate::operators::StaticOperator;
+use crate::operators::get_operator_handler;
 use crate::tests::assert_events;
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
@@ -13,18 +14,19 @@ use std::time::Duration;
 static TIMEOUT: Duration = Duration::from_millis(10);
 
 fn get_handler() -> OperatorHandler {
-    let timeout_manager = Rc::new(TimeoutManager::new());
+    let config: Vec<Expmap> = vec![Expmap {
+        name: "".into(),
+        chords: vec![],
+        remap: HashMap::from([(
+            Key::KEY_LEFTCTRL,
+            ExpmapOperator::DoubleTap(DoubleTap {
+                actions: vec![ExpmapAction::Key(Key::KEY_1)],
+                timeout: TIMEOUT,
+            }),
+        )]),
+    }];
 
-    let mut operators: Vec<Box<dyn StaticOperator>> = vec![];
-
-    operators.push(Box::new(DoubleTapOperator {
-        key: Key::KEY_LEFTCTRL,
-        actions: vec![ExpmapAction::Key(Key::KEY_1)],
-        timeout: TIMEOUT,
-        timeout_manager: timeout_manager.clone(),
-    }));
-
-    OperatorHandler::new(operators)
+    get_operator_handler(&config, Rc::new(TimeoutManager::new())).unwrap()
 }
 
 #[test]

--- a/src/tests_operator_handler.rs
+++ b/src/tests_operator_handler.rs
@@ -3,7 +3,6 @@ use crate::config::expmap_simkey::Simkey;
 use crate::config::Expmap;
 use crate::event::Event;
 use crate::operator_handler::OperatorHandler;
-use crate::operators::get_operator_handler;
 use crate::tests::assert_events;
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
@@ -54,7 +53,7 @@ fn get_handler() -> OperatorHandler {
         },
     ];
 
-    get_operator_handler(&config, Rc::new(TimeoutManager::new())).unwrap()
+    OperatorHandler::new(&config, Rc::new(TimeoutManager::new()))
 }
 
 #[test]

--- a/src/tests_operator_handler.rs
+++ b/src/tests_operator_handler.rs
@@ -1,12 +1,13 @@
-use crate::config::expmap_operator::ExpmapAction;
+use crate::config::expmap_operator::{DoubleTap, ExpmapAction, ExpmapOperator};
+use crate::config::expmap_simkey::Simkey;
+use crate::config::Expmap;
 use crate::event::Event;
-use crate::operator_double_tap::DoubleTapOperator;
 use crate::operator_handler::OperatorHandler;
-use crate::operator_sim::SimOperator;
-use crate::operators::StaticOperator;
+use crate::operators::get_operator_handler;
 use crate::tests::assert_events;
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
@@ -14,41 +15,46 @@ use std::time::Duration;
 static TIMEOUT: Duration = Duration::from_millis(10);
 
 fn get_handler() -> OperatorHandler {
-    let timeout_manager = Rc::new(TimeoutManager::new());
+    let config: Vec<Expmap> = vec![
+        Expmap {
+            name: "".into(),
+            chords: vec![],
+            // Operators that interact on KEY_H
+            // This has highest precedence.
+            remap: HashMap::from([(
+                Key::KEY_H,
+                ExpmapOperator::DoubleTap(DoubleTap {
+                    actions: vec![ExpmapAction::Key(Key::KEY_3), ExpmapAction::Key(Key::KEY_4)],
+                    timeout: TIMEOUT,
+                }),
+            )]),
+        },
+        Expmap {
+            name: "".into(),
+            chords: vec![
+                // Two operators that interact on KEY_B
+                Simkey {
+                    keys: vec![Key::KEY_A, Key::KEY_B],
+                    actions: vec![ExpmapAction::Key(Key::KEY_1)],
+                    timeout: TIMEOUT,
+                },
+                Simkey {
+                    keys: vec![Key::KEY_B, Key::KEY_C],
+                    actions: vec![ExpmapAction::Key(Key::KEY_2)],
+                    timeout: TIMEOUT,
+                },
+                // Operators that interact on KEY_H
+                Simkey {
+                    keys: vec![Key::KEY_H, Key::KEY_I],
+                    actions: vec![ExpmapAction::Key(Key::KEY_5)],
+                    timeout: TIMEOUT,
+                },
+            ],
+            remap: HashMap::new(),
+        },
+    ];
 
-    let mut operators: Vec<Box<dyn StaticOperator>> = vec![];
-
-    // Two operators that interact on KEY_B
-    operators.push(Box::new(SimOperator {
-        keys: vec![Key::KEY_A, Key::KEY_B],
-        actions: vec![ExpmapAction::Key(Key::KEY_1)],
-        timeout: TIMEOUT,
-        timeout_manager: timeout_manager.clone(),
-    }));
-
-    operators.push(Box::new(SimOperator {
-        keys: vec![Key::KEY_B, Key::KEY_C],
-        actions: vec![ExpmapAction::Key(Key::KEY_2)],
-        timeout: TIMEOUT,
-        timeout_manager: timeout_manager.clone(),
-    }));
-
-    // Two operators that interact on KEY_H
-    operators.push(Box::new(DoubleTapOperator {
-        key: Key::KEY_H,
-        actions: vec![ExpmapAction::Key(Key::KEY_3), ExpmapAction::Key(Key::KEY_4)],
-        timeout: TIMEOUT,
-        timeout_manager: timeout_manager.clone(),
-    }));
-
-    operators.push(Box::new(SimOperator {
-        keys: vec![Key::KEY_H, Key::KEY_I],
-        actions: vec![ExpmapAction::Key(Key::KEY_5)],
-        timeout: TIMEOUT,
-        timeout_manager: timeout_manager.clone(),
-    }));
-
-    OperatorHandler::new(operators)
+    get_operator_handler(&config, Rc::new(TimeoutManager::new())).unwrap()
 }
 
 #[test]

--- a/src/tests_operator_handler.rs
+++ b/src/tests_operator_handler.rs
@@ -55,11 +55,11 @@ fn get_handler() -> OperatorHandler {
 fn test_operator_handler_picks_heighest_candidate() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
     // Highest matches
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -69,13 +69,13 @@ fn test_operator_handler_picks_heighest_candidate() {
 fn test_operator_handler_picks_heighest_candidate_after_lowest_has_canceled() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_H)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_H)]), vec![]);
     // Other key to let lowest remain canceled a while.
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_H)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_H)]),
         vec![
             Event::key_press(Key::KEY_3),
             Event::key_press(Key::KEY_4),
@@ -84,7 +84,7 @@ fn test_operator_handler_picks_heighest_candidate_after_lowest_has_canceled() {
         ],
     );
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_H)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_H)]),
         vec![Event::key_release(Key::KEY_3), Event::key_release(Key::KEY_4)],
     );
 
@@ -96,15 +96,15 @@ fn test_operator_handler_picks_heighest_candidate_after_lowest_has_canceled() {
 fn test_operator_handler_picks_lowest_candidate_when_heighest_cancels() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
     // Lowest precedence match
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_C)]), vec![]);
     // Highest precedence cancels
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_B)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_B)]),
         vec![Event::key_press(Key::KEY_2), Event::key_release(Key::KEY_2)],
     );
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_C)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -114,22 +114,22 @@ fn test_operator_handler_picks_lowest_candidate_when_heighest_cancels() {
 fn test_operator_handler_picks_finished_lowest_candidate_when_heighest_cancels() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
     // Lowest precedence match
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_C)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_C)]), vec![]);
     // Extra event
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![]);
     // Highest precedence cancels (and the lowest goes into done)
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_B)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_B)]),
         vec![
             Event::key_press(Key::KEY_2),
             Event::key_release(Key::KEY_2),
             Event::key_press(Key::KEY_K),
         ],
     );
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -139,20 +139,20 @@ fn test_operator_handler_picks_finished_lowest_candidate_when_heighest_cancels()
 fn test_operator_handler_picks_lowest_candidate_done_a_while_when_heighest_matches() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_H)]), vec![]);
     // Lowest match
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_I)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_I)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_I)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_I)]), vec![]);
     // Lowest done
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_H)]), vec![]);
 
     // Other key to let lowest remain done a while.
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![]);
 
     // Highest precedence matches
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_H)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_H)]),
         vec![
             Event::key_press(Key::KEY_3),
             Event::key_press(Key::KEY_4),
@@ -164,7 +164,7 @@ fn test_operator_handler_picks_lowest_candidate_done_a_while_when_heighest_match
     );
 
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_H)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_H)]),
         vec![Event::key_release(Key::KEY_3), Event::key_release(Key::KEY_4)],
     );
 
@@ -176,21 +176,21 @@ fn test_operator_handler_picks_lowest_candidate_done_a_while_when_heighest_match
 fn test_operator_handler_picks_lowest_candidate_finished_a_while_when_heighest_cancels_by_timeout() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_H)]), vec![]);
     // Lowest match
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_I)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_I)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_I)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_I)]), vec![]);
     // Lowest done
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_H)]), vec![]);
 
     // Other key to let lowest remain done a while.
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![]);
 
     // Highest precedence cancels
     thread::sleep(TIMEOUT);
     assert_events(
-        handler.map_events(vec![Event::Tick]),
+        handler.map_evs(vec![Event::Tick]),
         vec![
             Event::key_press(Key::KEY_5),
             Event::key_release(Key::KEY_5),
@@ -207,20 +207,20 @@ fn test_operator_handler_picks_lowest_candidate_finished_a_while_when_heighest_c
 fn test_operator_handler_picks_lowest_candidate_when_canceled_by_timeout() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
     // Lowest precedence match
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_C)]), vec![]);
     // Lowest precedence virtually emits
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_C)]), vec![]);
 
     // Highest precedence cancels, and lowest gets emitted.
     thread::sleep(TIMEOUT);
     assert_events(
-        handler.map_events(vec![Event::Tick]),
+        handler.map_evs(vec![Event::Tick]),
         vec![Event::key_press(Key::KEY_2), Event::key_release(Key::KEY_2)],
     );
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -230,9 +230,9 @@ fn test_operator_handler_picks_lowest_candidate_when_canceled_by_timeout() {
 fn test_operator_handler_two_candidates_that_both_cancel() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_B)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_B)]),
         vec![Event::key_press(Key::KEY_B), Event::key_release(Key::KEY_B)],
     );
 
@@ -245,14 +245,14 @@ fn test_operator_handler_unhandled_events_are_passed_to_next_operator_when_cance
     let mut handler = get_handler();
 
     // 1st operator
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
     // 2nd operator (not candidate yet)
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_C)]), vec![]);
     // Cancel 1st
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
     // Cancel 2nd
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_C)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_C)]),
         vec![
             Event::key_press(Key::KEY_C),
             Event::key_release(Key::KEY_A),
@@ -269,19 +269,19 @@ fn test_operator_handler_unhandled_events_are_passed_to_next_operator_at_match()
     let mut handler = get_handler();
 
     // 1st operator
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
     // 2nd operator (not candidate yet)
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_C)]), vec![]);
     // 1st match
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
 
     // 2nd cancel (can't match because 1st consumed KEY_B)
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_C)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_C)]),
         vec![Event::key_press(Key::KEY_C), Event::key_release(Key::KEY_C)],
     );
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -292,19 +292,19 @@ fn test_operator_handler_unhandled_events_are_passed_to_static_operators_when_do
     let mut handler = get_handler();
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_A), Event::key_press(Key::KEY_B)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_A), Event::key_press(Key::KEY_B)]),
         vec![Event::key_press(Key::KEY_1)],
     );
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
 
     // Start new operator (of same type)
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
     // Last event to 1st operator
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
     // Cancel 2nd operator
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_A)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_A)]),
         vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
     );
 
@@ -317,7 +317,7 @@ fn test_operator_handler_candidate_match_in_one_batch() {
     let mut handler = get_handler();
 
     assert_events(
-        handler.map_events(vec![
+        handler.map_evs(vec![
             Event::key_press(Key::KEY_A),
             Event::key_press(Key::KEY_B),
             Event::key_release(Key::KEY_A),
@@ -335,7 +335,7 @@ fn test_operator_handler_candidate_cancels_in_one_batch() {
     let mut handler = get_handler();
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)]),
         vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
     );
 
@@ -347,17 +347,17 @@ fn test_operator_handler_candidate_cancels_in_one_batch() {
 fn test_operator_handler_candidate_with_many_actions() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_H)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_H)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_H)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_O)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_O)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_O)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_O)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_P)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_P)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_P)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_P)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_H)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_H)]),
         vec![
             Event::key_press(Key::KEY_3),
             Event::key_press(Key::KEY_4),
@@ -368,7 +368,7 @@ fn test_operator_handler_candidate_with_many_actions() {
         ],
     );
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_H)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_H)]),
         vec![Event::key_release(Key::KEY_3), Event::key_release(Key::KEY_4)],
     );
 

--- a/src/tests_operator_handler.rs
+++ b/src/tests_operator_handler.rs
@@ -27,6 +27,8 @@ fn get_handler() -> OperatorHandler {
                     timeout: TIMEOUT,
                 }),
             )]),
+            application: None,
+            window: None,
         },
         Expmap {
             name: "".into(),
@@ -50,6 +52,8 @@ fn get_handler() -> OperatorHandler {
                 },
             ],
             remap: HashMap::new(),
+            application: None,
+            window: None,
         },
     ];
 

--- a/src/tests_operator_sim.rs
+++ b/src/tests_operator_sim.rs
@@ -1,11 +1,13 @@
 use crate::config::expmap_operator::ExpmapAction;
+use crate::config::expmap_simkey::Simkey;
+use crate::config::Expmap;
 use crate::event::Event;
 use crate::operator_handler::OperatorHandler;
-use crate::operator_sim::SimOperator;
-use crate::operators::StaticOperator;
+use crate::operators::get_operator_handler;
 use crate::tests::assert_events;
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
@@ -13,25 +15,24 @@ use std::time::Duration;
 static TIMEOUT: Duration = Duration::from_millis(10);
 
 fn get_handler() -> OperatorHandler {
-    let timeout_manager = Rc::new(TimeoutManager::new());
+    let config: Vec<Expmap> = vec![Expmap {
+        name: "".into(),
+        chords: vec![
+            Simkey {
+                keys: vec![Key::KEY_A, Key::KEY_B],
+                actions: vec![ExpmapAction::Key(Key::KEY_1)],
+                timeout: TIMEOUT,
+            },
+            Simkey {
+                keys: vec![Key::KEY_C, Key::KEY_D, Key::KEY_E],
+                actions: vec![ExpmapAction::Key(Key::KEY_2)],
+                timeout: TIMEOUT,
+            },
+        ],
+        remap: HashMap::new(),
+    }];
 
-    let mut operators: Vec<Box<dyn StaticOperator>> = vec![];
-
-    operators.push(Box::new(SimOperator {
-        keys: vec![Key::KEY_A, Key::KEY_B],
-        actions: vec![ExpmapAction::Key(Key::KEY_1)],
-        timeout: TIMEOUT,
-        timeout_manager: timeout_manager.clone(),
-    }));
-
-    operators.push(Box::new(SimOperator {
-        keys: vec![Key::KEY_C, Key::KEY_D, Key::KEY_E],
-        actions: vec![ExpmapAction::Key(Key::KEY_2)],
-        timeout: TIMEOUT,
-        timeout_manager: timeout_manager.clone(),
-    }));
-
-    OperatorHandler::new(operators)
+    get_operator_handler(&config, Rc::new(TimeoutManager::new())).unwrap()
 }
 
 #[test]

--- a/src/tests_operator_sim.rs
+++ b/src/tests_operator_sim.rs
@@ -38,9 +38,9 @@ fn get_handler() -> OperatorHandler {
 fn symkey_test_first_key_released_before_second_is_pressed() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_A)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_A)]),
         vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
     );
 
@@ -52,11 +52,11 @@ fn symkey_test_first_key_released_before_second_is_pressed() {
 fn symkey_pressed_then_timeout() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
 
     thread::sleep(TIMEOUT);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![Event::key_press(Key::KEY_A)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -66,16 +66,16 @@ fn symkey_pressed_then_timeout() {
 fn symkey_pressed_then_release_of_old_other_key() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
 
     thread::sleep(TIMEOUT);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![Event::key_press(Key::KEY_B)]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![Event::key_press(Key::KEY_B)]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_A)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_A)]),
         vec![
             Event::key_press(Key::KEY_A),
             Event::key_release(Key::KEY_B),
@@ -91,7 +91,7 @@ fn symkey_pressed_then_release_of_old_other_key() {
 fn simkey_test_releasing_key_does_not_start_matching() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -101,16 +101,16 @@ fn simkey_test_releasing_key_does_not_start_matching() {
 fn symkey_emitted_then_timeout() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
 
     thread::sleep(TIMEOUT);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -120,10 +120,10 @@ fn symkey_emitted_then_timeout() {
 fn symkey_test_emitted_key_is_released_when_first_trigger_key_is_released() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -133,12 +133,12 @@ fn symkey_test_emitted_key_is_released_when_first_trigger_key_is_released() {
 fn symkey_test_trigger_then_modded_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_1)]);
     // Modded release order
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -148,12 +148,12 @@ fn symkey_test_trigger_then_modded_release() {
 fn symkey_test_trigger_then_rolled_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_1)]);
     // Rolled release order
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -163,12 +163,12 @@ fn symkey_test_trigger_then_rolled_release() {
 fn symkey_test_trigger_in_reverse_then_modded_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
     // Modded release order
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -178,12 +178,12 @@ fn symkey_test_trigger_in_reverse_then_modded_release() {
 fn symkey_test_trigger_in_reverse_then_rolled_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
     // Rolling release order
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -193,16 +193,16 @@ fn symkey_test_trigger_in_reverse_then_rolled_release() {
 fn symkey_released_then_timeout() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_1)]);
 
     thread::sleep(TIMEOUT);
 
-    assert_events(handler.map_events(vec![Event::Tick]), vec![]);
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -212,16 +212,16 @@ fn symkey_released_then_timeout() {
 fn symkey_test_second_key_can_start_matching_right_after_other_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_A)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_A)]),
         vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
     );
 
     // Matching starts on the other key.
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_B)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_B)]),
         vec![Event::key_press(Key::KEY_B), Event::key_release(Key::KEY_B)],
     );
 
@@ -233,16 +233,16 @@ fn symkey_test_second_key_can_start_matching_right_after_other_release() {
 fn symkey_test_surrounded_at_first_press() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_B)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_B)]),
         vec![Event::key_press(Key::KEY_1), Event::key_release(Key::KEY_K)],
     );
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -252,19 +252,19 @@ fn symkey_test_surrounded_at_first_press() {
 fn symkey_test_surrounded_at_first_press_and_cancel() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![]);
 
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_A)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_A)]),
         vec![
             Event::key_press(Key::KEY_A),
             Event::key_release(Key::KEY_K),
             Event::key_release(Key::KEY_A),
         ],
     );
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_B)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_B)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -274,16 +274,16 @@ fn symkey_test_surrounded_at_first_press_and_cancel() {
 fn symkey_test_surrounded_at_emit() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_press(Key::KEY_B)]),
+        handler.map_evs(vec![Event::key_press(Key::KEY_B)]),
         vec![Event::key_press(Key::KEY_1), Event::key_press(Key::KEY_K)],
     );
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -293,13 +293,13 @@ fn symkey_test_surrounded_at_emit() {
 fn symkey_test_surrounded_at_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -309,13 +309,13 @@ fn symkey_test_surrounded_at_release() {
 fn symkey_test_surrounded_at_done() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -325,30 +325,30 @@ fn symkey_test_surrounded_at_done() {
 fn symkey_test_repeat() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
 
     // Only one of the trigger keys send repeat events.
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
 
     // Unrelated repeat
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_K)]), vec![Event::key_repeat(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_K)]), vec![Event::key_repeat(Key::KEY_K)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
 
     // Repeat must be squashed, because the action has been released.
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
 
     // Repeat unrelated key
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_K)]), vec![Event::key_repeat(Key::KEY_K)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_K)]), vec![Event::key_repeat(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -358,25 +358,25 @@ fn symkey_test_repeat() {
 fn symkey_test_repeat_after_release() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_1)]);
 
     // Only one of the trigger keys send repeat events.
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_1)]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_1)]);
 
     // Repeat must be squashed, because action has been released.
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_B)]), vec![]);
 
     // Repeat trigger key after release (it's buffered until canceled by A-release)
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_A)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
     assert_events(
-        handler.map_events(vec![Event::key_release(Key::KEY_A)]),
+        handler.map_evs(vec![Event::key_release(Key::KEY_A)]),
         vec![
             Event::key_press(Key::KEY_A),
             Event::key_repeat(Key::KEY_A),
@@ -384,7 +384,7 @@ fn symkey_test_repeat_after_release() {
         ],
     );
 
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_B)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();
@@ -394,12 +394,12 @@ fn symkey_test_repeat_after_release() {
 fn symkey_test_3_simkeys() {
     let mut handler = get_handler();
 
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_E)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_C)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_press(Key::KEY_D)]), vec![Event::key_press(Key::KEY_2)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_D)]), vec![Event::key_release(Key::KEY_2)]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_C)]), vec![]);
-    assert_events(handler.map_events(vec![Event::key_release(Key::KEY_E)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_E)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_D)]), vec![Event::key_press(Key::KEY_2)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_D)]), vec![Event::key_release(Key::KEY_2)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_C)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_E)]), vec![]);
 
     handler.assert_base_state();
     handler.assert_emitted_modifiers_are_synced();

--- a/src/tests_operator_sim.rs
+++ b/src/tests_operator_sim.rs
@@ -3,7 +3,6 @@ use crate::config::expmap_simkey::Simkey;
 use crate::config::Expmap;
 use crate::event::Event;
 use crate::operator_handler::OperatorHandler;
-use crate::operators::get_operator_handler;
 use crate::tests::assert_events;
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
@@ -32,7 +31,7 @@ fn get_handler() -> OperatorHandler {
         remap: HashMap::new(),
     }];
 
-    get_operator_handler(&config, Rc::new(TimeoutManager::new())).unwrap()
+    OperatorHandler::new(&config, Rc::new(TimeoutManager::new()))
 }
 
 #[test]

--- a/src/tests_operator_sim.rs
+++ b/src/tests_operator_sim.rs
@@ -29,6 +29,8 @@ fn get_handler() -> OperatorHandler {
             },
         ],
         remap: HashMap::new(),
+        application: None,
+        window: None,
     }];
 
     OperatorHandler::new(&config, Rc::new(TimeoutManager::new()))


### PR DESCRIPTION
Make `window` and `application` matching work as it does in `keymap` and `modmap` already.

Example:
```yml
experimental_map:
  - application:
      only: konsole
    remap:
      Capslock:
        double: mute
```
