### PR TITLE
Fix with_mark to add shift correctly.

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -644,7 +644,11 @@ impl EventHandler {
     }
 
     fn with_mark(&self, key_press: &KeyPress) -> KeyPress {
-        if self.mark_set && !Modifier::Shift.is_in(&self.modifiers) {
+        let has_shift = key_press.modifiers.contains(&Modifier::Shift)
+            || key_press.modifiers.contains(&Modifier::Key(Key::KEY_LEFTSHIFT))
+            || key_press.modifiers.contains(&Modifier::Key(Key::KEY_RIGHTSHIFT));
+
+        if self.mark_set && !has_shift {
             let mut modifiers = key_press.modifiers.clone();
             modifiers.push(Modifier::Shift);
             KeyPress {

--- a/src/tests_keymap_mark.rs
+++ b/src/tests_keymap_mark.rs
@@ -1,6 +1,6 @@
 use crate::action::Action;
 use crate::event::{Event, KeyEvent, KeyValue};
-use crate::tests::assert_actions;
+use crate::tests::{assert_actions, EventHandlerForTest};
 use evdev::KeyCode as Key;
 use indoc::indoc;
 use std::time::Duration;
@@ -48,4 +48,162 @@ fn test_emacs_like() {
             Action::Delay(Duration::from_nanos(0)),
         ],
     )
+}
+
+#[test]
+fn test_mark_triggered_by_shift_combo() {
+    let mut handler = EventHandlerForTest::new(indoc! {"
+        keymap:
+            - remap:
+                f12: { set_mark: true }
+                A: { with_mark: '1' }
+                S-B: { with_mark: '2' }
+        "});
+
+    handler.assert(vec![Event::key_press(Key::KEY_F12)], vec![]);
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    );
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_LEFTSHIFT), Event::key_press(Key::KEY_B)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}
+
+#[test]
+fn test_mark_triggered_by_shift_combo_and_emits_shift_combo() {
+    let mut handler = EventHandlerForTest::new(indoc! {"
+        keymap:
+            - remap:
+                f12: { set_mark: true }
+                A: { with_mark: S-1 }
+                S-B: { with_mark: S-2 }
+        "});
+
+    handler.assert(vec![Event::key_press(Key::KEY_F12)], vec![]);
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    );
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_LEFTSHIFT), Event::key_press(Key::KEY_B)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}
+
+#[test]
+fn test_mark_triggered_with_extra_modifiers() {
+    let mut handler = EventHandlerForTest::new(indoc! {"
+        keymap:
+            - remap:
+                f12: { set_mark: true }
+                A: { with_mark: '1' }
+                S-B: { with_mark: '2' }
+        "});
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_F12), Event::key_press(Key::KEY_LEFTCTRL)],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press))],
+    );
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    );
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_LEFTSHIFT), Event::key_press(Key::KEY_B)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    );
+}
+
+#[test]
+fn test_mark_triggered_with_extra_modifiers_and_emits_shift_combo() {
+    let mut handler = EventHandlerForTest::new(indoc! {"
+        keymap:
+            - remap:
+                f12: { set_mark: true }
+                A: { with_mark: S_L-1 }
+                S-B: { with_mark: S_R-2 }
+        "});
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_F12), Event::key_press(Key::KEY_LEFTCTRL)],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press))],
+    );
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_A)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    );
+
+    handler.assert(
+        vec![Event::key_press(Key::KEY_LEFTSHIFT), Event::key_press(Key::KEY_B)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_RIGHTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_RIGHTSHIFT, KeyValue::Release)),
+        ],
+    );
 }


### PR DESCRIPTION
`with_mark` only added shift if a physical shift wasn't pressed. But should add a shift if `key_press` doesn't already have shift, which this PR now ensures.

It worked most of the time, because adding a double shift press is rarely a problem. So it only failed if the remapping is triggered with a shift as modifier. A corner case, that is only just discovered (#924).

