### PR TITLE
Update nix crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,12 +249,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -970,15 +964,6 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1009,24 +994,23 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1086,12 +1070,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -1267,7 +1245,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1654,7 +1632,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -1797,7 +1775,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -1822,7 +1800,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -1834,7 +1812,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -1846,7 +1824,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2080,7 +2058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -2155,7 +2133,7 @@ dependencies = [
  "lazy_static",
  "log",
  "niri-ipc",
- "nix 0.26.4",
+ "nix 0.31.3",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = {version = "0.3", optional = true}
 indoc = "2.0"
 lazy_static = "1.5.0"
 log = "0.4.29"
-nix = "0.26.2"
+nix = { version = "0.31", features = ["inotify", "poll", "time", "signal", "user"] }
 niri-ipc = { version = "25.11.0", optional = true }
 regex = "1.12.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/device.rs
+++ b/src/device.rs
@@ -8,10 +8,10 @@ use std::collections::HashMap;
 #[cfg(feature = "udev")]
 use std::fs::metadata;
 use std::fs::{self, read_dir};
+use std::os::fd::{AsFd, BorrowedFd};
 #[cfg(feature = "udev")]
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{io, process};
@@ -239,9 +239,9 @@ impl From<InputDevice> for (PathBuf, InputDevice) {
     }
 }
 
-impl AsRawFd for InputDevice {
-    fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
-        self.device.as_raw_fd()
+impl AsFd for InputDevice {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.device.as_fd()
     }
 }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -18,6 +18,7 @@ use nix::sys::timerfd::{Expiration, TimerFd, TimerSetTimeFlags};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
+use std::os::fd::{AsRawFd, RawFd};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
@@ -59,6 +60,20 @@ pub struct EventHandler {
 struct TaggedAction {
     action: KeymapAction,
     exact_match: bool,
+}
+
+#[cfg(target_os = "linux")]
+impl AsRawFd for EventHandler {
+    fn as_raw_fd(&self) -> RawFd {
+        self.override_timer.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl AsRawFd for &EventHandler {
+    fn as_raw_fd(&self) -> RawFd {
+        self.override_timer.as_raw_fd()
+    }
 }
 
 impl EventHandler {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -18,7 +18,7 @@ use nix::sys::timerfd::{Expiration, TimerFd, TimerSetTimeFlags};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, BorrowedFd};
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
@@ -63,9 +63,9 @@ struct TaggedAction {
 }
 
 #[cfg(target_os = "linux")]
-impl AsRawFd for EventHandler {
-    fn as_raw_fd(&self) -> RawFd {
-        self.override_timer.as_raw_fd()
+impl AsFd for EventHandler {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.override_timer.as_fd()
     }
 }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -69,13 +69,6 @@ impl AsRawFd for EventHandler {
     }
 }
 
-#[cfg(target_os = "linux")]
-impl AsRawFd for &EventHandler {
-    fn as_raw_fd(&self) -> RawFd {
-        self.override_timer.as_raw_fd()
-    }
-}
-
 impl EventHandler {
     pub fn new(
         #[cfg(target_os = "linux")] override_timer: TimerFd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use nix::libc::ENODEV;
 use nix::sys::select::{select, FdSet};
 use std::collections::HashMap;
 use std::io::stdout;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
@@ -234,8 +234,6 @@ fn main() -> anyhow::Result<()> {
     let watch_config = watch.contains(&WatchTargets::Config);
 
     let timeout_manager = Rc::new(TimeoutManager::new());
-    #[cfg(target_os = "linux")]
-    let timeout_manager_fd = timeout_manager.get_timer_fd();
 
     // Device name
     let own_device: String = output_device_name.unwrap_or_else(choose_device_name);
@@ -299,7 +297,7 @@ fn main() -> anyhow::Result<()> {
                 #[cfg(target_os = "linux")]
                 &handler,
                 #[cfg(target_os = "linux")]
-                timeout_manager_fd,
+                &timeout_manager,
             )?;
 
             #[cfg(target_os = "linux")]
@@ -317,7 +315,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             #[cfg(target_os = "linux")]
-            if readable_fds.contains(timeout_manager_fd) {
+            if readable_fds.contains(timeout_manager.as_raw_fd()) {
                 if timeout_manager.need_timeout()? {
                     if let Err(error) = handle_events(
                         &mut handler,
@@ -394,13 +392,13 @@ fn select_readable<'a>(
     device_watcher: &Option<DeviceWatcher>,
     config_watcher: &Option<ConfigWatcher>,
     #[cfg(target_os = "linux")] event_handler: impl AsRawFd,
-    #[cfg(target_os = "linux")] timeout_manager_fd: RawFd,
+    #[cfg(target_os = "linux")] timeout_manager: &Rc<TimeoutManager>,
 ) -> anyhow::Result<FdSet> {
     let mut read_fds = FdSet::new();
     #[cfg(target_os = "linux")]
     read_fds.insert(event_handler.as_raw_fd());
     #[cfg(target_os = "linux")]
-    read_fds.insert(timeout_manager_fd);
+    read_fds.insert(timeout_manager.as_raw_fd());
     for device in devices {
         read_fds.insert(device.as_raw_fd());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use nix::libc::ENODEV;
 use nix::sys::select::{select, FdSet};
 use std::collections::HashMap;
 use std::io::stdout;
+use std::os::fd::RawFd;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -301,7 +302,7 @@ fn main() -> anyhow::Result<()> {
             )?;
 
             #[cfg(target_os = "linux")]
-            if readable_fds.contains((&handler).as_raw_fd()) {
+            if readable_fds.contains(&handler.as_raw_fd()) {
                 if let Err(error) = handle_events(
                     &mut handler,
                     &mut dispatcher,
@@ -315,7 +316,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             #[cfg(target_os = "linux")]
-            if readable_fds.contains(timeout_manager.as_raw_fd()) {
+            if readable_fds.contains(&timeout_manager.as_raw_fd()) {
                 if timeout_manager.need_timeout()? {
                     if let Err(error) = handle_events(
                         &mut handler,
@@ -331,7 +332,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             for input_device in input_devices.values_mut() {
-                if !readable_fds.contains(input_device.as_raw_fd()) {
+                if !readable_fds.contains(&input_device.as_raw_fd()) {
                     continue;
                 }
 
@@ -391,9 +392,9 @@ fn select_readable<'a>(
     devices: impl Iterator<Item = &'a InputDevice>,
     device_watcher: &Option<DeviceWatcher>,
     config_watcher: &Option<ConfigWatcher>,
-    #[cfg(target_os = "linux")] event_handler: impl AsRawFd,
+    #[cfg(target_os = "linux")] event_handler: &impl AsRawFd,
     #[cfg(target_os = "linux")] timeout_manager: &Rc<TimeoutManager>,
-) -> anyhow::Result<FdSet> {
+) -> anyhow::Result<Vec<RawFd>> {
     let mut read_fds = FdSet::new();
     #[cfg(target_os = "linux")]
     read_fds.insert(event_handler.as_raw_fd());
@@ -412,7 +413,9 @@ fn select_readable<'a>(
         read_fds.insert(config_watcher.borrow_inotify().as_raw_fd());
     }
     select(None, &mut read_fds, None, None, None)?;
-    Ok(read_fds)
+
+    // Make the result independent of borrowed fds
+    Ok(read_fds.fds(None).map(|fd| fd.as_raw_fd()).collect())
 }
 
 // Return false when a removed device is found.

--- a/src/main.rs
+++ b/src/main.rs
@@ -408,8 +408,8 @@ fn select_readable<'a>(
     }
     #[cfg(target_os = "linux")]
     if let Some(config_watcher) = config_watcher {
-        read_fds.insert(config_watcher.timer_fd);
-        read_fds.insert(config_watcher.inotify.as_raw_fd());
+        read_fds.insert(config_watcher.borrow_timer().as_raw_fd());
+        read_fds.insert(config_watcher.borrow_inotify().as_raw_fd());
     }
     select(None, &mut read_fds, None, None, None)?;
     Ok(read_fds)

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,8 +243,6 @@ fn main() -> anyhow::Result<()> {
     // Event listeners
     #[cfg(target_os = "linux")]
     let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
-    #[cfg(target_os = "linux")]
-    let timer_fd = timer.as_raw_fd();
     let delay = Duration::from_millis(config.keypress_delay_ms);
     let mut input_devices = select_input_devices(&device_filter, &ignore_filter, mouse, watch_devices, &own_device)?;
     let device_watcher = DeviceWatcher::new(watch_devices).context("Setting up device watcher")?;
@@ -299,13 +297,13 @@ fn main() -> anyhow::Result<()> {
                 &device_watcher,
                 &config_watcher,
                 #[cfg(target_os = "linux")]
-                timer_fd,
+                &handler,
                 #[cfg(target_os = "linux")]
                 timeout_manager_fd,
             )?;
 
             #[cfg(target_os = "linux")]
-            if readable_fds.contains(timer_fd) {
+            if readable_fds.contains((&handler).as_raw_fd()) {
                 if let Err(error) = handle_events(
                     &mut handler,
                     &mut dispatcher,
@@ -395,12 +393,12 @@ fn select_readable<'a>(
     devices: impl Iterator<Item = &'a InputDevice>,
     device_watcher: &Option<DeviceWatcher>,
     config_watcher: &Option<ConfigWatcher>,
-    #[cfg(target_os = "linux")] timer_fd: RawFd,
+    #[cfg(target_os = "linux")] event_handler: impl AsRawFd,
     #[cfg(target_os = "linux")] timeout_manager_fd: RawFd,
 ) -> anyhow::Result<FdSet> {
     let mut read_fds = FdSet::new();
     #[cfg(target_os = "linux")]
-    read_fds.insert(timer_fd);
+    read_fds.insert(event_handler.as_raw_fd());
     #[cfg(target_os = "linux")]
     read_fds.insert(timeout_manager_fd);
     for device in devices {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use nix::libc::ENODEV;
 use nix::sys::select::{select, FdSet};
 use std::collections::HashMap;
 use std::io::stdout;
-use std::os::fd::RawFd;
+use std::os::fd::{AsFd, RawFd};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -302,7 +302,7 @@ fn main() -> anyhow::Result<()> {
             )?;
 
             #[cfg(target_os = "linux")]
-            if readable_fds.contains(&handler.as_raw_fd()) {
+            if readable_fds.contains(&handler.as_fd().as_raw_fd()) {
                 if let Err(error) = handle_events(
                     &mut handler,
                     &mut dispatcher,
@@ -316,7 +316,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             #[cfg(target_os = "linux")]
-            if readable_fds.contains(&timeout_manager.as_raw_fd()) {
+            if readable_fds.contains(&timeout_manager.as_fd().as_raw_fd()) {
                 if timeout_manager.need_timeout()? {
                     if let Err(error) = handle_events(
                         &mut handler,
@@ -332,7 +332,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             for input_device in input_devices.values_mut() {
-                if !readable_fds.contains(&input_device.as_raw_fd()) {
+                if !readable_fds.contains(&input_device.as_fd().as_raw_fd()) {
                     continue;
                 }
 
@@ -392,25 +392,25 @@ fn select_readable<'a>(
     devices: impl Iterator<Item = &'a InputDevice>,
     device_watcher: &Option<DeviceWatcher>,
     config_watcher: &Option<ConfigWatcher>,
-    #[cfg(target_os = "linux")] event_handler: &impl AsRawFd,
+    #[cfg(target_os = "linux")] event_handler: &impl AsFd,
     #[cfg(target_os = "linux")] timeout_manager: &Rc<TimeoutManager>,
 ) -> anyhow::Result<Vec<RawFd>> {
     let mut read_fds = FdSet::new();
     #[cfg(target_os = "linux")]
-    read_fds.insert(event_handler.as_raw_fd());
+    read_fds.insert(event_handler.as_fd());
     #[cfg(target_os = "linux")]
-    read_fds.insert(timeout_manager.as_raw_fd());
+    read_fds.insert(timeout_manager.as_fd());
     for device in devices {
-        read_fds.insert(device.as_raw_fd());
+        read_fds.insert(device.as_fd());
     }
     #[cfg(target_os = "linux")]
     if let Some(device_watcher) = device_watcher {
-        read_fds.insert(device_watcher.as_raw_fd());
+        read_fds.insert(device_watcher.as_fd());
     }
     #[cfg(target_os = "linux")]
     if let Some(config_watcher) = config_watcher {
-        read_fds.insert(config_watcher.borrow_timer().as_raw_fd());
-        read_fds.insert(config_watcher.borrow_inotify().as_raw_fd());
+        read_fds.insert(config_watcher.borrow_timer());
+        read_fds.insert(config_watcher.borrow_inotify());
     }
     select(None, &mut read_fds, None, None, None)?;
 

--- a/src/platform_freebsd/config_watcher.rs
+++ b/src/platform_freebsd/config_watcher.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::main_controller::MainController;
 use anyhow::Result;
 use nix::sys::select::FdSet;
+use std::os::fd::RawFd;
 use std::path::PathBuf;
 
 pub struct ConfigWatcher {}
@@ -14,7 +15,7 @@ impl ConfigWatcher {
         return Ok(None);
     }
 
-    pub fn handle(&mut self, _readable_fds: FdSet, _mainctrl: &mut MainController) -> Result<Option<Config>> {
+    pub fn handle(&mut self, _readable_fds: Vec<RawFd>, _mainctrl: &mut MainController) -> Result<Option<Config>> {
         unreachable!()
     }
 }

--- a/src/platform_linux/config_watcher.rs
+++ b/src/platform_linux/config_watcher.rs
@@ -5,7 +5,7 @@ use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, InotifyEvent};
 use nix::sys::select::FdSet;
 use nix::sys::time::TimeSpec;
 use nix::sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -14,9 +14,8 @@ pub struct ConfigWatcher {
     files: Vec<PathBuf>,
     debounce: Option<Duration>,
     notifications: bool,
-    pub timer_fd: RawFd,
     timer: TimerFd,
-    pub inotify: Inotify,
+    inotify: Inotify,
     change_pending: bool,
 }
 
@@ -35,8 +34,6 @@ impl ConfigWatcher {
             inotify.add_watch(file, AddWatchFlags::IN_MODIFY)?;
         }
 
-        let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
-
         let debounce = if debounce_ms == 0 {
             None
         } else {
@@ -47,8 +44,7 @@ impl ConfigWatcher {
             files,
             debounce,
             notifications,
-            timer_fd: timer.as_raw_fd(),
-            timer,
+            timer: TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?,
             inotify,
             change_pending: false,
         };
@@ -56,8 +52,16 @@ impl ConfigWatcher {
         Ok(Some(this))
     }
 
+    pub fn borrow_timer<'a>(&'a self) -> &'a TimerFd {
+        &self.timer
+    }
+
+    pub fn borrow_inotify<'a>(&'a self) -> &'a Inotify {
+        &self.inotify
+    }
+
     pub fn handle(&mut self, readable_fds: FdSet, mainctrl: &mut MainController) -> Result<Option<Config>> {
-        if readable_fds.contains(self.timer_fd) {
+        if readable_fds.contains(self.timer.as_raw_fd()) {
             return Ok(Some(self.get_config(mainctrl)?));
         }
 

--- a/src/platform_linux/config_watcher.rs
+++ b/src/platform_linux/config_watcher.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, InotifyEvent};
 use nix::sys::time::TimeSpec;
 use nix::sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags};
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -51,16 +51,16 @@ impl ConfigWatcher {
         Ok(Some(this))
     }
 
-    pub fn borrow_timer<'a>(&'a self) -> &'a TimerFd {
-        &self.timer
+    pub fn borrow_timer<'a>(&'a self) -> BorrowedFd<'a> {
+        self.timer.as_fd()
     }
 
-    pub fn borrow_inotify<'a>(&'a self) -> &'a Inotify {
-        &self.inotify
+    pub fn borrow_inotify<'a>(&'a self) -> BorrowedFd<'a> {
+        self.inotify.as_fd()
     }
 
     pub fn handle(&mut self, readable_fds: Vec<RawFd>, mainctrl: &mut MainController) -> Result<Option<Config>> {
-        if readable_fds.contains(&self.timer.as_raw_fd()) {
+        if readable_fds.contains(&self.timer.as_fd().as_raw_fd()) {
             return Ok(Some(self.get_config(mainctrl)?));
         }
 

--- a/src/platform_linux/config_watcher.rs
+++ b/src/platform_linux/config_watcher.rs
@@ -2,10 +2,9 @@ use crate::config::{load_configs, Config};
 use crate::main_controller::MainController;
 use anyhow::Result;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify, InotifyEvent};
-use nix::sys::select::FdSet;
 use nix::sys::time::TimeSpec;
 use nix::sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags};
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -60,8 +59,8 @@ impl ConfigWatcher {
         &self.inotify
     }
 
-    pub fn handle(&mut self, readable_fds: FdSet, mainctrl: &mut MainController) -> Result<Option<Config>> {
-        if readable_fds.contains(self.timer.as_raw_fd()) {
+    pub fn handle(&mut self, readable_fds: Vec<RawFd>, mainctrl: &mut MainController) -> Result<Option<Config>> {
+        if readable_fds.contains(&self.timer.as_raw_fd()) {
             return Ok(Some(self.get_config(mainctrl)?));
         }
 

--- a/src/platform_linux/device_watcher.rs
+++ b/src/platform_linux/device_watcher.rs
@@ -1,5 +1,5 @@
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, BorrowedFd};
 use std::path::PathBuf;
 
 #[derive(Debug)]
@@ -7,9 +7,9 @@ pub struct DeviceWatcher {
     inotify: Inotify,
 }
 
-impl AsRawFd for DeviceWatcher {
-    fn as_raw_fd(&self) -> RawFd {
-        self.inotify.as_raw_fd()
+impl AsFd for DeviceWatcher {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.inotify.as_fd()
     }
 }
 

--- a/src/timeout_manager.rs
+++ b/src/timeout_manager.rs
@@ -9,41 +9,28 @@ static RESOLUTION: Duration = Duration::from_millis(1);
 
 #[derive(Debug)]
 struct State {
-    #[cfg(target_os = "linux")]
-    timer_fd: RawFd,
-    #[cfg(target_os = "linux")]
-    timer: TimerFd,
     delays: Vec<Instant>,
 }
 
 #[derive(Debug)]
 pub struct TimeoutManager {
+    #[cfg(target_os = "linux")]
+    timer: TimerFd,
     state: RefCell<State>,
 }
 
 impl TimeoutManager {
     pub fn new() -> Self {
-        #[cfg(target_os = "linux")]
-        let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap();
         Self {
-            state: RefCell::new(State {
-                #[cfg(target_os = "linux")]
-                timer_fd: timer.as_raw_fd(),
-                #[cfg(target_os = "linux")]
-                timer,
-                delays: vec![],
-            }),
+            #[cfg(target_os = "linux")]
+            timer: TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap(),
+            state: RefCell::new(State { delays: vec![] }),
         }
-    }
-
-    #[cfg(target_os = "linux")]
-    pub fn get_timer_fd(&self) -> RawFd {
-        self.state.borrow().timer_fd
     }
 
     pub fn set_timeout(&self, delay: Duration) -> nix::Result<()> {
         #[cfg(target_os = "linux")]
-        return set_timeout(&mut self.state.borrow_mut(), delay);
+        return set_timeout(&mut self.state.borrow_mut(), delay, &self.timer);
         #[cfg(target_os = "freebsd")]
         panic!("Double tap and chords are not supported on FreeBSD");
     }
@@ -52,13 +39,20 @@ impl TimeoutManager {
         #[cfg(target_os = "freebsd")]
         return Ok(false);
         #[cfg(target_os = "linux")]
-        need_timeout(&mut self.state.borrow_mut())
+        need_timeout(&mut self.state.borrow_mut(), &self.timer)
     }
 }
 
 #[cfg(target_os = "linux")]
-fn set_timeout(state: &mut State, delay: Duration) -> nix::Result<()> {
-    set_timer(state)?;
+impl AsRawFd for TimeoutManager {
+    fn as_raw_fd(&self) -> RawFd {
+        self.timer.as_raw_fd()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn set_timeout(state: &mut State, delay: Duration, timer: &TimerFd) -> nix::Result<()> {
+    set_timer(timer)?;
 
     state.delays.push(Instant::now() + delay);
 
@@ -66,7 +60,7 @@ fn set_timeout(state: &mut State, delay: Duration) -> nix::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn need_timeout(state: &mut State) -> anyhow::Result<bool> {
+fn need_timeout(state: &mut State, timer: &TimerFd) -> anyhow::Result<bool> {
     let now = Instant::now();
 
     let need_timeout = state.delays.iter().any(|timeout_inst| timeout_inst <= &now);
@@ -74,9 +68,9 @@ fn need_timeout(state: &mut State) -> anyhow::Result<bool> {
     state.delays.retain(|&timeout_inst| timeout_inst > now);
 
     if state.delays.is_empty() {
-        state.timer.unset()?;
+        timer.unset()?;
     } else {
-        set_timer(state)?;
+        set_timer(timer)?;
     }
 
     Ok(need_timeout)
@@ -84,8 +78,6 @@ fn need_timeout(state: &mut State) -> anyhow::Result<bool> {
 
 #[cfg(target_os = "linux")]
 // Could pick the minimal delay to avoid unneeded ticks.
-fn set_timer(state: &mut State) -> nix::Result<()> {
-    state
-        .timer
-        .set(Expiration::OneShot(TimeSpec::from_duration(RESOLUTION)), TimerSetTimeFlags::empty())
+fn set_timer(timer: &TimerFd) -> nix::Result<()> {
+    timer.set(Expiration::OneShot(TimeSpec::from_duration(RESOLUTION)), TimerSetTimeFlags::empty())
 }

--- a/src/timeout_manager.rs
+++ b/src/timeout_manager.rs
@@ -8,15 +8,10 @@ use std::time::{Duration, Instant};
 static RESOLUTION: Duration = Duration::from_millis(1);
 
 #[derive(Debug)]
-struct State {
-    delays: Vec<Instant>,
-}
-
-#[derive(Debug)]
 pub struct TimeoutManager {
     #[cfg(target_os = "linux")]
     timer: TimerFd,
-    state: RefCell<State>,
+    delays: RefCell<Vec<Instant>>,
 }
 
 impl TimeoutManager {
@@ -24,13 +19,13 @@ impl TimeoutManager {
         Self {
             #[cfg(target_os = "linux")]
             timer: TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap(),
-            state: RefCell::new(State { delays: vec![] }),
+            delays: RefCell::new(vec![]),
         }
     }
 
     pub fn set_timeout(&self, delay: Duration) -> nix::Result<()> {
         #[cfg(target_os = "linux")]
-        return set_timeout(&mut self.state.borrow_mut(), delay, &self.timer);
+        return set_timeout(&mut self.delays.borrow_mut(), delay, &self.timer);
         #[cfg(target_os = "freebsd")]
         panic!("Double tap and chords are not supported on FreeBSD");
     }
@@ -39,7 +34,7 @@ impl TimeoutManager {
         #[cfg(target_os = "freebsd")]
         return Ok(false);
         #[cfg(target_os = "linux")]
-        need_timeout(&mut self.state.borrow_mut(), &self.timer)
+        need_timeout(&mut self.delays.borrow_mut(), &self.timer)
     }
 }
 
@@ -51,23 +46,23 @@ impl AsRawFd for TimeoutManager {
 }
 
 #[cfg(target_os = "linux")]
-fn set_timeout(state: &mut State, delay: Duration, timer: &TimerFd) -> nix::Result<()> {
+fn set_timeout(delays: &mut Vec<Instant>, delay: Duration, timer: &TimerFd) -> nix::Result<()> {
     set_timer(timer)?;
 
-    state.delays.push(Instant::now() + delay);
+    delays.push(Instant::now() + delay);
 
     Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn need_timeout(state: &mut State, timer: &TimerFd) -> anyhow::Result<bool> {
+fn need_timeout(delays: &mut Vec<Instant>, timer: &TimerFd) -> anyhow::Result<bool> {
     let now = Instant::now();
 
-    let need_timeout = state.delays.iter().any(|timeout_inst| timeout_inst <= &now);
+    let need_timeout = delays.iter().any(|timeout_inst| timeout_inst <= &now);
 
-    state.delays.retain(|&timeout_inst| timeout_inst > now);
+    delays.retain(|&timeout_inst| timeout_inst > now);
 
-    if state.delays.is_empty() {
+    if delays.is_empty() {
         timer.unset()?;
     } else {
         set_timer(timer)?;

--- a/src/timeout_manager.rs
+++ b/src/timeout_manager.rs
@@ -2,7 +2,8 @@ use nix::sys::time::TimeSpec;
 #[cfg(target_os = "linux")]
 use nix::sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags};
 use std::cell::RefCell;
-use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsFd, BorrowedFd};
 use std::time::{Duration, Instant};
 
 static RESOLUTION: Duration = Duration::from_millis(1);
@@ -39,9 +40,9 @@ impl TimeoutManager {
 }
 
 #[cfg(target_os = "linux")]
-impl AsRawFd for TimeoutManager {
-    fn as_raw_fd(&self) -> RawFd {
-        self.timer.as_raw_fd()
+impl AsFd for TimeoutManager {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.timer.as_fd()
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use evdev::{AttributeSet, BusType, Device, EventType, FetchEventsSynced, InputEv
 use nix::sys::select::{select, FdSet};
 use nix::sys::time::TimeValLike;
 use std::iter::repeat_with;
-use std::os::unix::io::AsRawFd;
+use std::os::fd::AsFd;
 use std::path::PathBuf;
 use std::time::Duration;
 use xremap::util::{until, until_value};
@@ -178,12 +178,11 @@ pub fn containsn(count: u64, hackstack: &str, needle: &str) -> bool {
 
 pub fn fetch_events(device: &mut Device) -> anyhow::Result<FetchEventsSynced<'_>> {
     let mut fds = FdSet::new();
-    let fd = device.as_raw_fd();
-    fds.insert(fd);
+    fds.insert(device.as_fd());
 
     select(None, &mut fds, None, None, Some(&mut TimeValLike::seconds(1)))?;
 
-    if !fds.contains(fd) {
+    if !fds.contains(device.as_fd()) {
         bail!("Timed out waiting for xremap events.");
     }
 


### PR DESCRIPTION
The breaking changes that was made adaptions for, is `nix`'s change to requiring `AsFd` instead of `AsRawFd`.