### PR TITLE
Update FreeBSD action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,17 +74,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
-        with:
-          key: ubuntu-latest-freebsd
 
-      - run: cargo install cross
-
-      - name: cross build freebsd
-        run: cross build --target=x86_64-unknown-freebsd
+      - name: Compile in VM
+        uses: cross-platform-actions/action@492b0c80085400348c599edace11141a4ee73524
+        with:
+          operating_system: freebsd
+          version: "15.0"
+          run: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            . "$HOME/.cargo/env"
+            cargo build
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`cross` doesn't support multiple versions of FreeBSD and the version is fixed to FreeBSD 13, which doesn't have support for `TimerFd`.

Instead is `cross-platform-actions/action` used.
