### PR TITLE
Add FreeBSD support for key sequences, double tap and chords.

### DIFF
--- a/doc/reference_freebsd.md
+++ b/doc/reference_freebsd.md
@@ -12,10 +12,14 @@ pkg install rust
 #### Compile xremap
 
 ```sh
-cargo build --release --features x11
+cargo install xremap --features x11
 ```
 
-The compiled binary has the path `target/release/xremap`.
+Check it works:
+
+```sh
+xremap --version
+```
 
 #### Set permissions
 

--- a/doc/reference_freebsd.md
+++ b/doc/reference_freebsd.md
@@ -51,11 +51,6 @@ setxkbmap gb
 
 [The problem is also described here](https://forums.freebsd.org/threads/keyboard-layout-keeps-getting-messed-up.95081/)
 
-#### Key sequences, double tap and chords are not supported
-
-The cause is missing `TimerFd` in [nix crate](https://github.com/nix-rust/nix). But that seems to
-be added in [`v0.31.2`](https://github.com/nix-rust/nix/blob/master/CHANGELOG.md), so an update might fix that.
-
 #### Config and device watching is not supported
 
 The cause is missing `Inotify` in [nix crate](https://github.com/nix-rust/nix). There is

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -13,7 +13,6 @@ use evdev::KeyCode as Key;
 use lazy_static::lazy_static;
 use log::{debug, warn};
 use nix::sys::time::TimeSpec;
-#[cfg(target_os = "linux")]
 use nix::sys::timerfd::{Expiration, TimerFd, TimerSetTimeFlags};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -43,7 +42,6 @@ pub struct EventHandler {
     // Key triggered on a timeout of nested remaps
     override_timeout_key: Option<Vec<Key>>,
     // Trigger a timeout of nested remaps through select(2)
-    #[cfg(target_os = "linux")]
     override_timer: TimerFd,
     // { set_mode: String }
     mode: String,
@@ -62,7 +60,6 @@ struct TaggedAction {
     exact_match: bool,
 }
 
-#[cfg(target_os = "linux")]
 impl AsFd for EventHandler {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.override_timer.as_fd()
@@ -70,11 +67,7 @@ impl AsFd for EventHandler {
 }
 
 impl EventHandler {
-    pub fn new(
-        #[cfg(target_os = "linux")] override_timer: TimerFd,
-        mode: &str,
-        keypress_delay: Duration,
-    ) -> EventHandler {
+    pub fn new(override_timer: TimerFd, mode: &str, keypress_delay: Duration) -> EventHandler {
         EventHandler {
             modifiers: vec![],
             extra_modifiers: HashSet::new(),
@@ -82,7 +75,6 @@ impl EventHandler {
             multi_purpose_keys: HashMap::new(),
             override_remaps: vec![],
             override_timeout_key: None,
-            #[cfg(target_os = "linux")]
             override_timer,
             mode: mode.to_string(),
             mark_set: false,
@@ -202,7 +194,6 @@ impl EventHandler {
     }
 
     fn remove_override(&mut self) -> Result<(), Box<dyn Error>> {
-        #[cfg(target_os = "linux")]
         self.override_timer.unset()?;
         self.override_remaps.clear();
         self.override_timeout_key = None;
@@ -595,10 +586,6 @@ impl EventHandler {
                 // Set timeout only if this is the first of multiple eligible remaps,
                 // so the behaviour is consistent with how current normal keymap override works
                 if set_timeout {
-                    #[cfg(target_os = "freebsd")]
-                    panic!("Key sequences not supported on FreeBSD");
-
-                    #[cfg(target_os = "linux")]
                     if let Some(timeout) = timeout {
                         let expiration = Expiration::OneShot(TimeSpec::from_duration(*timeout));
                         // TODO: Consider handling the timer in ActionDispatcher

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use device::InputDevice;
 use event::Event;
 use nix::libc::ENODEV;
 use nix::sys::select::{select, FdSet};
+use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
 use std::collections::HashMap;
 use std::io::stdout;
 use std::os::fd::{AsFd, RawFd};
@@ -30,8 +31,6 @@ use std::time::Duration;
 mod platform_linux;
 #[cfg(target_os = "linux")]
 use crate::platform_linux::{ConfigWatcher, DeviceWatcher};
-#[cfg(target_os = "linux")]
-use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
 #[cfg(target_os = "freebsd")]
 mod platform_freebsd;
 #[cfg(target_os = "freebsd")]
@@ -240,7 +239,6 @@ fn main() -> anyhow::Result<()> {
     let own_device: String = output_device_name.unwrap_or_else(choose_device_name);
 
     // Event listeners
-    #[cfg(target_os = "linux")]
     let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
     let delay = Duration::from_millis(config.keypress_delay_ms);
     let mut input_devices = select_input_devices(&device_filter, &ignore_filter, mouse, watch_devices, &own_device)?;
@@ -253,12 +251,7 @@ fn main() -> anyhow::Result<()> {
     let mut mainctrl = MainController::new(!no_window_logging, allow_launch.unwrap_or(true));
 
     // EventHandler
-    let mut handler = EventHandler::new(
-        #[cfg(target_os = "linux")]
-        timer,
-        &config.default_mode,
-        delay,
-    );
+    let mut handler = EventHandler::new(timer, &config.default_mode, delay);
     let vendor = u16::from_str_radix(vendor.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x1234);
     let product = u16::from_str_radix(product.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x5678);
     let output_device = output_device(
@@ -295,13 +288,11 @@ fn main() -> anyhow::Result<()> {
                 input_devices.values(),
                 &device_watcher,
                 &config_watcher,
-                #[cfg(target_os = "linux")]
                 &handler,
                 #[cfg(target_os = "linux")]
                 &timeout_manager,
             )?;
 
-            #[cfg(target_os = "linux")]
             if readable_fds.contains(&handler.as_fd().as_raw_fd()) {
                 if let Err(error) = handle_events(
                     &mut handler,
@@ -392,11 +383,10 @@ fn select_readable<'a>(
     devices: impl Iterator<Item = &'a InputDevice>,
     device_watcher: &Option<DeviceWatcher>,
     config_watcher: &Option<ConfigWatcher>,
-    #[cfg(target_os = "linux")] event_handler: &impl AsFd,
+    event_handler: &impl AsFd,
     #[cfg(target_os = "linux")] timeout_manager: &Rc<TimeoutManager>,
 ) -> anyhow::Result<Vec<RawFd>> {
     let mut read_fds = FdSet::new();
-    #[cfg(target_os = "linux")]
     read_fds.insert(event_handler.as_fd());
     #[cfg(target_os = "linux")]
     read_fds.insert(timeout_manager.as_fd());

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,14 +284,8 @@ fn main() -> anyhow::Result<()> {
         }
 
         'event_loop: loop {
-            let readable_fds = select_readable(
-                input_devices.values(),
-                &device_watcher,
-                &config_watcher,
-                &handler,
-                #[cfg(target_os = "linux")]
-                &timeout_manager,
-            )?;
+            let readable_fds =
+                select_readable(input_devices.values(), &device_watcher, &config_watcher, &handler, &timeout_manager)?;
 
             if readable_fds.contains(&handler.as_fd().as_raw_fd()) {
                 if let Err(error) = handle_events(
@@ -306,7 +300,6 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
-            #[cfg(target_os = "linux")]
             if readable_fds.contains(&timeout_manager.as_fd().as_raw_fd()) {
                 if timeout_manager.need_timeout()? {
                     if let Err(error) = handle_events(
@@ -384,11 +377,10 @@ fn select_readable<'a>(
     device_watcher: &Option<DeviceWatcher>,
     config_watcher: &Option<ConfigWatcher>,
     event_handler: &impl AsFd,
-    #[cfg(target_os = "linux")] timeout_manager: &Rc<TimeoutManager>,
+    timeout_manager: &Rc<TimeoutManager>,
 ) -> anyhow::Result<Vec<RawFd>> {
     let mut read_fds = FdSet::new();
     read_fds.insert(event_handler.as_fd());
-    #[cfg(target_os = "linux")]
     read_fds.insert(timeout_manager.as_fd());
     for device in devices {
         read_fds.insert(device.as_fd());

--- a/src/timeout_manager.rs
+++ b/src/timeout_manager.rs
@@ -1,8 +1,6 @@
 use nix::sys::time::TimeSpec;
-#[cfg(target_os = "linux")]
 use nix::sys::timerfd::{ClockId, Expiration, TimerFd, TimerFlags, TimerSetTimeFlags};
 use std::cell::RefCell;
-#[cfg(target_os = "linux")]
 use std::os::fd::{AsFd, BorrowedFd};
 use std::time::{Duration, Instant};
 
@@ -10,7 +8,6 @@ static RESOLUTION: Duration = Duration::from_millis(1);
 
 #[derive(Debug)]
 pub struct TimeoutManager {
-    #[cfg(target_os = "linux")]
     timer: TimerFd,
     delays: RefCell<Vec<Instant>>,
 }
@@ -18,35 +15,26 @@ pub struct TimeoutManager {
 impl TimeoutManager {
     pub fn new() -> Self {
         Self {
-            #[cfg(target_os = "linux")]
             timer: TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty()).unwrap(),
             delays: RefCell::new(vec![]),
         }
     }
 
     pub fn set_timeout(&self, delay: Duration) -> nix::Result<()> {
-        #[cfg(target_os = "linux")]
-        return set_timeout(&mut self.delays.borrow_mut(), delay, &self.timer);
-        #[cfg(target_os = "freebsd")]
-        panic!("Double tap and chords are not supported on FreeBSD");
+        set_timeout(&mut self.delays.borrow_mut(), delay, &self.timer)
     }
 
     pub fn need_timeout(&self) -> anyhow::Result<bool> {
-        #[cfg(target_os = "freebsd")]
-        return Ok(false);
-        #[cfg(target_os = "linux")]
         need_timeout(&mut self.delays.borrow_mut(), &self.timer)
     }
 }
 
-#[cfg(target_os = "linux")]
 impl AsFd for TimeoutManager {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.timer.as_fd()
     }
 }
 
-#[cfg(target_os = "linux")]
 fn set_timeout(delays: &mut Vec<Instant>, delay: Duration, timer: &TimerFd) -> nix::Result<()> {
     set_timer(timer)?;
 
@@ -55,7 +43,6 @@ fn set_timeout(delays: &mut Vec<Instant>, delay: Duration, timer: &TimerFd) -> n
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
 fn need_timeout(delays: &mut Vec<Instant>, timer: &TimerFd) -> anyhow::Result<bool> {
     let now = Instant::now();
 
@@ -72,7 +59,6 @@ fn need_timeout(delays: &mut Vec<Instant>, timer: &TimerFd) -> anyhow::Result<bo
     Ok(need_timeout)
 }
 
-#[cfg(target_os = "linux")]
 // Could pick the minimal delay to avoid unneeded ticks.
 fn set_timer(timer: &TimerFd) -> nix::Result<()> {
     timer.set(Expiration::OneShot(TimeSpec::from_duration(RESOLUTION)), TimerSetTimeFlags::empty())


### PR DESCRIPTION
The blocker for these features was `TimerFd` in [nix crate](https://github.com/nix-rust/nix). Support was added in [`nix@v0.31.2`](https://github.com/nix-rust/nix/blob/master/CHANGELOG.md).

These features will work on FreeBSD 14 and later.
